### PR TITLE
bump light client version

### DIFF
--- a/lightclient/docker-compose.yml
+++ b/lightclient/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     build:
       context: .
       dockerfile_inline: |
-        FROM ubuntu:22.04@sha256:01a3ee0b5e413cefaaffc6abe68c9c37879ae3cced56a8e088b1649e5b269eee
+        FROM ubuntu:24.04@sha256:b59d21599a2b151e23eea5f6602f4af4d7d31c4e236d22bf0b62b86d2e386b8f
         RUN apt-get update && apt install -y curl wget
         WORKDIR /root
 
@@ -17,7 +17,7 @@ services:
         RUN tar -xzf ./foundry_nightly_linux_amd64.tar.gz -C /usr/local/bin
 
         # Helios
-        RUN curl -L 'https://github.com/a16z/helios/releases/download/0.7.0/helios_linux_amd64.tar.gz' | tar -xzC .
+        RUN curl -L 'https://github.com/a16z/helios/releases/download/0.8.8/helios_linux_amd64.tar.gz' | tar -xzC .
 
         CMD [ "bash", "/root/run.sh" ]
     platform: linux/amd64
@@ -27,7 +27,7 @@ configs:
       # First run Helios in the background
       # Provide a reasonable checkpoint.
       (
-      /root/helios ethereum --network=holesky --checkpoint 0x9260657ed4167f2bbe57317978ff181b6b96c1065ecf9340bba05ba3578128fe \
+      /root/helios ethereum --network=holesky --checkpoint 0x60409a013161b33c8c68c6183c7753e779ec6c24be2f3c50c6036c30e13b34a6 \
       --consensus-rpc http://testing.holesky.beacon-api.nimbus.team --execution-rpc $${ETH_RPC_URL}
       ) &
 


### PR DESCRIPTION
helios 8.8 is needed to sync on holesky now, this requires a newer version of ubuntu.