### PR TITLE
ingress: Support for gRPC proxy

### DIFF
--- a/custom-domain/dstack-ingress/README.md
+++ b/custom-domain/dstack-ingress/README.md
@@ -53,7 +53,7 @@ The fastest way to get started is to use our pre-built image. Simply use the fol
 ```yaml
 services:
   dstack-ingress:
-    image: kvin/dstack-ingress@sha256:0f9d97aee13764895f967a00874418330a56e20cf4b0a4c2700934c5755b3350
+    image: kvin/dstack-ingress@sha256:b61d50360c7a4e5ab7d22f5ce87677714f3f64a65db34ee5eebcc54683950c89
     ports:
       - "443:443"
     environment:
@@ -109,6 +109,37 @@ docker push yourusername/dstack-ingress:tag
 ```
 
 4. Update the docker-compose.yaml file with your image name and deploy
+
+
+#### gRPC Support
+
+If your dstack application uses gRPC, you can set `TARGET_ENDPOINT` to `grpc://app:50051`.
+
+example:
+
+```yaml
+services:
+  dstack-ingress:
+    image: kvin/dstack-ingress@sha256:b61d50360c7a4e5ab7d22f5ce87677714f3f64a65db34ee5eebcc54683950c89
+    ports:
+      - "443:443"
+    environment:
+      - CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN}
+      - DOMAIN=${DOMAIN}
+      - GATEWAY_DOMAIN=${GATEWAY_DOMAIN}
+      - CERTBOT_EMAIL=${CERTBOT_EMAIL}
+      - SET_CAA=true
+      - TARGET_ENDPOINT=grpc://app:50051
+    volumes:
+      - /var/run/tappd.sock:/var/run/tappd.sock
+      - cert-data:/etc/letsencrypt
+    restart: unless-stopped
+  app:
+    image: your-grpc-app
+    restart: unless-stopped
+volumes:
+  cert-data:
+```
 
 ## Domain Attestation and Verification
 

--- a/custom-domain/dstack-ingress/docker-compose.yaml
+++ b/custom-domain/dstack-ingress/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   dstack-ingress:
-    image: kvin/dstack-ingress@sha256:0f9d97aee13764895f967a00874418330a56e20cf4b0a4c2700934c5755b3350
+    image: kvin/dstack-ingress@sha256:b61d50360c7a4e5ab7d22f5ce87677714f3f64a65db34ee5eebcc54683950c89
     ports:
       - "443:443"
     environment:

--- a/custom-domain/dstack-ingress/scripts/entrypoint.sh
+++ b/custom-domain/dstack-ingress/scripts/entrypoint.sh
@@ -12,6 +12,11 @@ setup_py_env() {
     pip install certbot-dns-cloudflare==4.0.0
 }
 
+PROXY_CMD="proxy"
+if [[ "${TARGET_ENDPOINT}" == grpc://* ]]; then
+    PROXY_CMD="grpc"
+fi
+
 setup_nginx_conf() {
     cat <<EOF > /etc/nginx/conf.d/default.conf
 server {
@@ -54,11 +59,11 @@ server {
     ssl_early_data off;
     
     location / {
-        proxy_pass ${TARGET_ENDPOINT};
-        proxy_set_header Host \$host;
-        proxy_set_header X-Real-IP \$remote_addr;
-        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto \$scheme;
+        ${PROXY_CMD}_pass ${TARGET_ENDPOINT};
+        ${PROXY_CMD}_set_header Host \$host;
+        ${PROXY_CMD}_set_header X-Real-IP \$remote_addr;
+        ${PROXY_CMD}_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        ${PROXY_CMD}_set_header X-Forwarded-Proto \$scheme;
     }
 
     location /evidences/ {

--- a/launcher/build-image.sh
+++ b/launcher/build-image.sh
@@ -10,6 +10,6 @@ if ! docker buildx inspect buildkit_20 &>/dev/null; then
 fi
 touch pinned-packages.txt
 git rev-parse HEAD > .GIT_REV
-docker buildx build --builder buildkit_20 --no-cache --build-arg SOURCE_DATE_EPOCH="0" --output type=docker,name=$NAME,rewrite-timestamp=true .
+docker buildx build --platform linux/amd64 --builder buildkit_20 --no-cache --build-arg SOURCE_DATE_EPOCH="0" --output type=docker,name=$NAME,rewrite-timestamp=true .
 docker run --rm --entrypoint bash $NAME -c "dpkg -l | grep '^ii' |awk '{print \$2\"=\"\$3}' | sort" > pinned-packages.txt
 rm .GIT_REV


### PR DESCRIPTION
This PR adds support for reverse proxy to gRPC backend to the dstack-ingress example.
You only need to config the `TARGET_ENDPOINT` with prefix `grpc://` to enable it.

Resolves https://github.com/Dstack-TEE/dstack/issues/278