### PR TITLE
ci: update CodeQL action from v3 to v4

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -63,22 +63,22 @@ jobs:
           fi
 
       - name: Upload Hadolint results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: hadolint-results.sarif
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: python
           queries: security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:python"
 


### PR DESCRIPTION
## Summary
- Updates all CodeQL action references from v3 to v4 to resolve deprecation warning
- Affects: upload-sarif, init, autobuild, and analyze actions

## Test plan
- [x] Verify security scan workflow runs successfully
- [x] Confirm no CodeQL v3 deprecation warnings
- [x] Check that SARIF upload and analysis complete without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)