### PR TITLE
custom domain nginx reverse proxy header size

### DIFF
--- a/custom-domain/dstack-ingress/README.md
+++ b/custom-domain/dstack-ingress/README.md
@@ -180,6 +180,9 @@ configs:
 - `PROXY_READ_TIMEOUT`: Optional value for nginx `proxy_read_timeout` (numeric with optional `s|m|h` suffix, e.g. `30s`) in single-domain mode
 - `PROXY_SEND_TIMEOUT`: Optional value for nginx `proxy_send_timeout` (numeric with optional `s|m|h` suffix, e.g. `30s`) in single-domain mode
 - `PROXY_CONNECT_TIMEOUT`: Optional value for nginx `proxy_connect_timeout` (numeric with optional `s|m|h` suffix, e.g. `10s`) in single-domain mode
+- `PROXY_BUFFER_SIZE`: Optional value for nginx `proxy_buffer_size` (numeric with optional `k|m` suffix, e.g. `128k`) in single-domain mode
+- `PROXY_BUFFERS`: Optional value for nginx `proxy_buffers` (format: `number size`, e.g. `4 256k`) in single-domain mode
+- `PROXY_BUSY_BUFFERS_SIZE`: Optional value for nginx `proxy_busy_buffers_size` (numeric with optional `k|m` suffix, e.g. `256k`) in single-domain mode
 - `CERTBOT_STAGING`: Optional; set this value to the string `true` to set the `--staging` server option on the [`certbot` cli](https://eff-certbot.readthedocs.io/en/stable/using.html#certbot-command-line-options)
 
 **Backward Compatibility:**

--- a/custom-domain/dstack-ingress/scripts/functions.sh
+++ b/custom-domain/dstack-ingress/scripts/functions.sh
@@ -83,6 +83,35 @@ sanitize_proxy_timeout() {
     fi
 }
 
+sanitize_proxy_buffer_size() {
+    local candidate="$1"
+    if [ -z "$candidate" ]; then
+        echo ""
+        return 0
+    fi
+    if [[ "$candidate" =~ ^[0-9]+[kKmM]?$ ]]; then
+        echo "$candidate"
+    else
+        echo "Warning: Ignoring invalid proxy buffer size value: $candidate" >&2
+        echo ""
+    fi
+}
+
+sanitize_proxy_buffers() {
+    local candidate="$1"
+    if [ -z "$candidate" ]; then
+        echo ""
+        return 0
+    fi
+    # Format: number size (e.g., "4 256k")
+    if [[ "$candidate" =~ ^[0-9]+[[:space:]]+[0-9]+[kKmM]?$ ]]; then
+        echo "$candidate"
+    else
+        echo "Warning: Ignoring invalid proxy buffers value: $candidate (expected format: 'number size', e.g., '4 256k')" >&2
+        echo ""
+    fi
+}
+
 get_letsencrypt_account_path() {
     local base_path="/etc/letsencrypt/accounts"
     local api_endpoint="acme-v02.api.letsencrypt.org"


### PR DESCRIPTION
when we set large cookies, it creates a 502 error condition;  it is difficult to detect.

this PR lets us (optionally) add support for larger header payloads.