### PR TITLE
fix(ingress): re-obtain certificate when switching between staging and production

### DIFF
--- a/custom-domain/dstack-ingress/scripts/certman.py
+++ b/custom-domain/dstack-ingress/scripts/certman.py
@@ -383,13 +383,17 @@ class CertManager:
             result = subprocess.run(
                 cmd, capture_output=True, text=True, timeout=300)
 
+            stdout_output = result.stdout.strip() if result.stdout else ""
+            error_output = result.stderr.strip() if result.stderr else ""
+
             if result.returncode == 0:
+                # Check if certbot actually renewed anything
+                if "No renewals were attempted" in stdout_output:
+                    print("No certificates need renewal")
+                    return True, False
                 print(f"✓ Certificate renewal completed")
                 return True, True
             else:
-                error_output = result.stderr.strip() if result.stderr else ""
-                stdout_output = result.stdout.strip() if result.stdout else ""
-
                 print(
                     f"✗ Certificate renewal failed (exit code: {result.returncode})")
 
@@ -409,14 +413,6 @@ class CertManager:
 
                 return False, False
 
-            # Check if no renewals were needed
-            if "No renewals were attempted" in result.stdout:
-                print("No certificates need renewal")
-                return True, False
-
-            print("Certificate renewed successfully")
-            return True, True
-
         except Exception as e:
             print(f"Error running certbot: {e}", file=sys.stderr)
             return False, False
@@ -425,6 +421,23 @@ class CertManager:
         """Check if certificate already exists for domain."""
         cert_path = f"/etc/letsencrypt/live/{domain}/fullchain.pem"
         return os.path.isfile(cert_path)
+
+    def acme_account_exists(self) -> bool:
+        """Check if an ACME account exists for the current server (staging or production).
+
+        The account directory differs between staging and production:
+        - production: /etc/letsencrypt/accounts/acme-v02.api.letsencrypt.org/directory/
+        - staging:    /etc/letsencrypt/accounts/acme-staging-v02.api.letsencrypt.org/directory/
+
+        When switching between staging and production, the cert file persists
+        on the volume but the account only exists for the previous server.
+        """
+        import glob
+        api_endpoint = "acme-v02.api.letsencrypt.org"
+        if os.environ.get("CERTBOT_STAGING", "false") == "true":
+            api_endpoint = "acme-staging-v02.api.letsencrypt.org"
+        pattern = f"/etc/letsencrypt/accounts/{api_endpoint}/directory/*/regr.json"
+        return len(glob.glob(pattern)) > 0
 
     def run_action(
         self, domain: str, email: str, action: str = "auto"
@@ -435,10 +448,13 @@ class CertManager:
             (success, needs_evidence): success status and whether evidence should be generated
         """
         if action == "auto":
-            if self.certificate_exists(domain):
+            if self.certificate_exists(domain) and self.acme_account_exists():
                 success, renewed = self.renew_certificate(domain)
                 return success, renewed  # Only generate evidence if actually renewed
             else:
+                if self.certificate_exists(domain) and not self.acme_account_exists():
+                    print(f"Certificate exists for {domain} but ACME account is missing "
+                          f"(staging/production switch?), re-obtaining")
                 success = self.obtain_certificate(domain, email)
                 return success, success  # Always generate evidence for new certificates
         elif action == "obtain":


### PR DESCRIPTION
## Problem

When switching `CERTBOT_STAGING` between `true` and `false` (from production to staging), the dstack-ingress container enters a crash loop and HTTPS becomes completely unavailable.

### Root Cause

Certificate files and ACME account files are stored under different directory structures in `/etc/letsencrypt/`:

- **Cert files** are stored by **domain name** (same path regardless of staging/production):
  ```
  /etc/letsencrypt/live/example.com/fullchain.pem
  ```

- **ACME account files** are stored by **ACME server** (different path for staging vs production):
  ```
  production: /etc/letsencrypt/accounts/acme-v02.api.letsencrypt.org/directory/<hash>/regr.json
  staging:    /etc/letsencrypt/accounts/acme-staging-v02.api.letsencrypt.org/directory/<hash>/regr.json
  ```

When switching from production to staging (or vice versa), the `cert-data` Docker volume still has the old cert file, but the ACME account only exists under the previous server's directory. This triggers the following failure chain:

1. `certificate_exists()` returns `True` (cert file is per-domain, still exists)
2. Code takes the `renew` path instead of `obtain` (skips account registration)
3. `certbot renew --staging` exits 0 but does nothing useful (no matching renewal config for staging server)
4. Code prints "✓ Certificate renewal completed" (false positive — exit code 0 doesn't mean anything was renewed)
5. `generate-evidences.sh` looks for ACME account file under the staging path → not found → exits 1
6. `entrypoint.sh` has `set -e` → script exits → nginx never starts → container crash loops

## Fix

### 1. Check ACME account existence before deciding renew vs obtain

Add `acme_account_exists()` that checks if an account file exists for the **current** staging/production mode. The `auto` action now requires both cert file AND matching ACME account to take the `renew` path. When the account is missing, it falls through to `obtain_certificate()` which registers a new ACME account.

### 2. Fix false success reporting in `renew_certificate()`

`certbot renew` exits 0 even when "No renewals were attempted". Previously the code treated all exit-0 as successful renewal. Now it checks stdout for "No renewals were attempted" before reporting success, and correctly returns `(True, False)` instead of `(True, True)`.

### 3. Remove unreachable dead code

The "No renewals were attempted" check after the `if/else` block was dead code (unreachable after `return` statements). Removed.

## Test plan

- [x] Deploy with `CERTBOT_STAGING=true` on a fresh volume → should obtain cert via staging
- [x] Deploy with production cert on volume, then switch to `CERTBOT_STAGING=true` → should detect missing staging account and re-obtain
- [ ] Deploy with existing staging cert + account → should take normal renew path