### PR TITLE
fix(ingress): enable unbuffered Python output for real-time logging

### DIFF
--- a/custom-domain/dstack-ingress/Dockerfile
+++ b/custom-domain/dstack-ingress/Dockerfile
@@ -58,6 +58,7 @@ RUN --mount=type=bind,source=scripts,target=/tmp/scripts,ro \
 
 ENV PATH="/scripts:$PATH"
 ENV PYTHONPATH="/scripts"
+ENV PYTHONUNBUFFERED=1
 COPY --chmod=666 .GIT_REV /etc/
 
 ENTRYPOINT ["/scripts/entrypoint.sh"]


### PR DESCRIPTION
## Summary

- Add `PYTHONUNBUFFERED=1` to Dockerfile

Python stdout is fully buffered in containers (piped, not a terminal). This causes certman.py log output to be delayed and flushed in batches, making it look like there are multi-minute gaps in execution when in reality the delay is from certbot's DNS propagation wait.

## Test plan

- [ ] Deploy and check that Python log lines appear in real-time instead of in batches