### PR TITLE
DNS based (route53) load balancing and dstack-ingress upstream server support

### DIFF
--- a/custom-domain/dstack-ingress/DNS_PROVIDERS.md
+++ b/custom-domain/dstack-ingress/DNS_PROVIDERS.md
@@ -24,7 +24,7 @@ This guide explains how to configure dstack-ingress to work with different DNS p
 - `SET_CAA` - Enable CAA record setup (default: false)
 - `PORT` - HTTPS port (default: 443)
 - `TXT_PREFIX` - Prefix for TXT records (default: "_tapp-address")
-- `ALIAS_DOMAIN` - Public-facing domain shared across multiple nodes (e.g., `app.example.com`). Added as a SAN on the TLS certificate and to nginx `server_name`. When set alongside `ROUTE53_INITIAL_WEIGHT` (Route53 only), also creates a weight-0 weighted CNAME `ALIAS_DOMAIN → DOMAIN` to register this node in the pool without routing traffic to it. See [Weighted Routing with ALIAS_DOMAIN](#weighted-routing-with-alias_domain-route53).
+- `ALIAS_DOMAIN` - A shared domain that acts as a load-balanced entry point across multiple Phala nodes (e.g., `app.example.com`). Each node automatically joins the upstream pool on boot — users hit one address while traffic is distributed across however many nodes are running. See [Weighted Routing with ALIAS_DOMAIN](#weighted-routing-with-alias_domain-route53).
 
 ## Provider-Specific Configuration
 

--- a/custom-domain/dstack-ingress/DNS_PROVIDERS.md
+++ b/custom-domain/dstack-ingress/DNS_PROVIDERS.md
@@ -200,7 +200,7 @@ For multi-node weighted routing, see [Weighted Routing with ALIAS_DOMAIN](#weigh
 
 ## Weighted Routing with ALIAS_DOMAIN (Route53)
 
-This pattern lets you run multiple independent TEE nodes behind a single public domain using Route53 weighted routing. Each node manages its own Phala identity (TXT record, CNAME to gateway) while also being registered as a weighted target for the shared public domain.
+This pattern lets you run multiple independent TEE nodes behind a single public domain using Route53 weighted routing. Each node manages its own Phala identity (TXT record, CNAME to gateway) while also being registered as a weighted target for the shared public domain. Per-node domains also prevent hitting Let's Encrypt's duplicate-certificate rate limits that would occur if every node requested a cert for the same shared domain.
 
 ### DNS Record Layout
 
@@ -209,6 +209,9 @@ Public domain (shared across nodes)
 ────────────────────────────────────────────────────────────────
   app.example.com  CNAME  node1.app.example.com  weight=100  id=node1.app.example.com
   app.example.com  CNAME  node2.app.example.com  weight=0    id=node2.app.example.com  ← new, dark
+
+  _dstack-app-address.app.example.com  TXT  <appid1>:443   ← one entry per node in pool,
+                                            <appid2>:443      appended on each node boot
 
 Per-node records (managed by each node's dstack-ingress)
 ────────────────────────────────────────────────────────────────
@@ -278,6 +281,8 @@ volumes:
 ```
 
 Node 2 (`node2.app.example.com`) uses identical config with `DOMAIN: node2.app.example.com`. On first boot it registers itself at weight 0. To promote it, update the record weight in Route53.
+
+For a complete production-ready reference that includes a dynamic nginx upstream manager (automatically enrolling and unenrolling backend containers as they start and stop), see [`docker-compose.loadbalanced.yaml`](docker-compose.loadbalanced.yaml) in this repository.
 
 ### Important Notes
 

--- a/custom-domain/dstack-ingress/DNS_PROVIDERS.md
+++ b/custom-domain/dstack-ingress/DNS_PROVIDERS.md
@@ -13,7 +13,7 @@ This guide explains how to configure dstack-ingress to work with different DNS p
 
 ### Common Variables (Required for all providers)
 
-- `DOMAIN` - Your node-specific domain (e.g., `node1.app.example.com`)
+- `DOMAIN` - Your custom domain (e.g., `app.example.com`)
 - `GATEWAY_DOMAIN` - dstack gateway domain (e.g., `_.dstack-prod5.phala.network`)
 - `CERTBOT_EMAIL` - Email for Let's Encrypt registration
 - `TARGET_ENDPOINT` - Backend application endpoint to proxy to
@@ -172,17 +172,17 @@ services:
 ```yaml
 services:
   dstack-ingress:
-    image: dstacktee/dstack-ingress:20250929@sha256:2b47b3e538df0b3e7724255b89369194c8c83a7cfba64d2faf0115ad0a586458
+    image: dstack-ingress:latest
     restart: unless-stopped
     volumes:
-      - /var/run/tappd.sock:/var/run/tappd.sock
+      - /var/run/dstack.sock:/var/run/dstack.sock
       - cert-data:/etc/letsencrypt
     ports:
       - "443:443"
     environment:
       DNS_PROVIDER: route53
       DOMAIN: app.example.com
-      GATEWAY_DOMAIN: _.dstack-prod5.phala.network
+      GATEWAY_DOMAIN: _.${DSTACK_GATEWAY_DOMAIN}
 
       AWS_REGION: ${AWS_REGION}
       AWS_ROLE_ARN: ${AWS_ROLE_ARN}
@@ -252,7 +252,7 @@ Node 1 (`node1.app.example.com`):
 ```yaml
 services:
   dstack-ingress:
-    image: dstacktee/dstack-ingress:20250929@sha256:2b47b3e538df0b3e7724255b89369194c8c83a7cfba64d2faf0115ad0a586458
+    image: dstack-ingress:latest
     restart: unless-stopped
     ports:
       - "443:443"
@@ -260,7 +260,7 @@ services:
       DNS_PROVIDER: route53
       DOMAIN: node1.app.example.com
       ALIAS_DOMAIN: app.example.com
-      GATEWAY_DOMAIN: _.dstack-prod5.phala.network
+      GATEWAY_DOMAIN: _.${DSTACK_GATEWAY_DOMAIN}
       CERTBOT_EMAIL: ${CERTBOT_EMAIL}
       TARGET_ENDPOINT: http://app:80
       SET_CAA: 'true'
@@ -271,7 +271,7 @@ services:
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
     volumes:
-      - /var/run/tappd.sock:/var/run/tappd.sock
+      - /var/run/dstack.sock:/var/run/dstack.sock
       - cert-data:/etc/letsencrypt
 volumes:
   cert-data:

--- a/custom-domain/dstack-ingress/DNS_PROVIDERS.md
+++ b/custom-domain/dstack-ingress/DNS_PROVIDERS.md
@@ -175,10 +175,10 @@ services:
     image: dstack-ingress:latest
     restart: unless-stopped
     volumes:
-      - /var/run/dstack.sock:/var/run/dstack.sock
-      - cert-data:/etc/letsencrypt
+    - /var/run/dstack.sock:/var/run/dstack.sock
+    - cert-data:/etc/letsencrypt
     ports:
-      - "443:443"
+    - 443:443
     environment:
       DNS_PROVIDER: route53
       DOMAIN: app.example.com

--- a/custom-domain/dstack-ingress/DNS_PROVIDERS.md
+++ b/custom-domain/dstack-ingress/DNS_PROVIDERS.md
@@ -103,6 +103,9 @@ PolicyDocument:
         - route53:ListResourceRecordSets
 ```
 
+**Optional Variables for Route53:**
+- `ROUTE53_INITIAL_WEIGHT` - Enables [Weighted Routing](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy-weighted.html) on the CNAME record created for your domain. Set to an integer (e.g., `100`) to assign that weight to the record. A unique `SetIdentifier` is generated automatically. TXT records (used for Certbot DNS challenges) are never weighted. Omit this variable to create a standard non-weighted CNAME record.
+
 **Important Notes for Route53:**
 - The certbot plugin uses the format `certbot-dns-route53` package
 - CAA will merge AWS & Let's Encrypt CA domains to existing records if they exist

--- a/custom-domain/dstack-ingress/DNS_PROVIDERS.md
+++ b/custom-domain/dstack-ingress/DNS_PROVIDERS.md
@@ -13,17 +13,18 @@ This guide explains how to configure dstack-ingress to work with different DNS p
 
 ### Common Variables (Required for all providers)
 
-- `DOMAIN` - Your custom domain (e.g., `app.example.com`)
+- `DOMAIN` - Your node-specific domain (e.g., `node1.app.example.com`)
 - `GATEWAY_DOMAIN` - dstack gateway domain (e.g., `_.dstack-prod5.phala.network`)
 - `CERTBOT_EMAIL` - Email for Let's Encrypt registration
 - `TARGET_ENDPOINT` - Backend application endpoint to proxy to
-- `DNS_PROVIDER` - DNS provider to use (`cloudflare`, `linode`, `namecheap`)
+- `DNS_PROVIDER` - DNS provider to use (`cloudflare`, `linode`, `namecheap`, `route53`)
 
 ### Optional Variables
 
 - `SET_CAA` - Enable CAA record setup (default: false)
 - `PORT` - HTTPS port (default: 443)
 - `TXT_PREFIX` - Prefix for TXT records (default: "_tapp-address")
+- `ALIAS_DOMAIN` - Public-facing domain shared across multiple nodes (e.g., `app.example.com`). Added as a SAN on the TLS certificate and to nginx `server_name`. When set alongside `ROUTE53_INITIAL_WEIGHT` (Route53 only), also creates a weight-0 weighted CNAME `ALIAS_DOMAIN → DOMAIN` to register this node in the pool without routing traffic to it. See [Weighted Routing with ALIAS_DOMAIN](#weighted-routing-with-alias_domain-route53).
 
 ## Provider-Specific Configuration
 
@@ -104,11 +105,12 @@ PolicyDocument:
 ```
 
 **Optional Variables for Route53:**
-- `ROUTE53_INITIAL_WEIGHT` - Enables [Weighted Routing](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy-weighted.html) on the CNAME record created for your domain. Set to an integer (e.g., `100`) to assign that weight to the record. A unique `SetIdentifier` is generated automatically. TXT records (used for Certbot DNS challenges) are never weighted. Omit this variable to create a standard non-weighted CNAME record.
+- `ROUTE53_INITIAL_WEIGHT` - Enables [Weighted Routing](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy-weighted.html) on the CNAME record created for `DOMAIN` (e.g. `node1.app.example.com → phala gateway`). Set to an integer (e.g., `100`) to assign that weight to the record. A unique `SetIdentifier` is generated automatically. TXT records are never weighted. Omit to create a standard non-weighted CNAME. When `ALIAS_DOMAIN` is also set, this variable additionally triggers creation of a weight-0 weighted CNAME `ALIAS_DOMAIN → DOMAIN` — see below.
+- `ALIAS_DOMAIN` - See [Weighted Routing with ALIAS_DOMAIN](#weighted-routing-with-alias_domain-route53).
 
 **Important Notes for Route53:**
-- The certbot plugin uses the format `certbot-dns-route53` package
-- CAA will merge AWS & Let's Encrypt CA domains to existing records if they exist
+- The certbot plugin uses the `certbot-dns-route53` package
+- CAA will merge AWS & Let's Encrypt CA domains into existing records if they exist
 - It is essential that the AWS service account used can only assume the limited role. See cloudformation example.
 
 ## Docker Compose Examples
@@ -165,22 +167,22 @@ services:
       - ./evidences:/evidences
 ```
 
-### Route53 Example
+### Route53 Example (single node, no weighted routing)
 
 ```yaml
 services:
   dstack-ingress:
-    image: dstack-ingress:latest
+    image: dstacktee/dstack-ingress:20250929@sha256:2b47b3e538df0b3e7724255b89369194c8c83a7cfba64d2faf0115ad0a586458
     restart: unless-stopped
     volumes:
-    - /var/run/dstack.sock:/var/run/dstack.sock
-    - cert-data:/etc/letsencrypt
+      - /var/run/tappd.sock:/var/run/tappd.sock
+      - cert-data:/etc/letsencrypt
     ports:
-    - 443:443
+      - "443:443"
     environment:
       DNS_PROVIDER: route53
       DOMAIN: app.example.com
-      GATEWAY_DOMAIN: _.${DSTACK_GATEWAY_DOMAIN}
+      GATEWAY_DOMAIN: _.dstack-prod5.phala.network
 
       AWS_REGION: ${AWS_REGION}
       AWS_ROLE_ARN: ${AWS_ROLE_ARN}
@@ -190,8 +192,98 @@ services:
       CERTBOT_EMAIL: ${CERTBOT_EMAIL}
       TARGET_ENDPOINT: http://backend:8080
       SET_CAA: 'true'
+volumes:
+  cert-data:
+```
+
+For multi-node weighted routing, see [Weighted Routing with ALIAS_DOMAIN](#weighted-routing-with-alias_domain-route53).
+
+## Weighted Routing with ALIAS_DOMAIN (Route53)
+
+This pattern lets you run multiple independent TEE nodes behind a single public domain using Route53 weighted routing. Each node manages its own Phala identity (TXT record, CNAME to gateway) while also being registered as a weighted target for the shared public domain.
+
+### DNS Record Layout
 
 ```
+Public domain (shared across nodes)
+────────────────────────────────────────────────────────────────
+  app.example.com  CNAME  node1.app.example.com  weight=100  id=node1.app.example.com
+  app.example.com  CNAME  node2.app.example.com  weight=0    id=node2.app.example.com  ← new, dark
+
+Per-node records (managed by each node's dstack-ingress)
+────────────────────────────────────────────────────────────────
+  node1.app.example.com   CNAME  <appid1>.dstack-prod5.phala.network  weight=100
+  node2.app.example.com   CNAME  <appid2>.dstack-prod5.phala.network  weight=100
+
+  _dstack-app-address.node1.app.example.com  TXT  <appid1>:443
+  _dstack-app-address.node2.app.example.com  TXT  <appid2>:443
+
+TLS certificate (on each node)
+────────────────────────────────────────────────────────────────
+  Subject:  node1.app.example.com
+  SAN:      app.example.com
+```
+
+### Variable Interactions
+
+| `ALIAS_DOMAIN` | `ROUTE53_INITIAL_WEIGHT` | Cert SAN | Nginx server_name | Weight-0 CNAME for ALIAS_DOMAIN |
+|---|---|---|---|---|
+| not set | any | no | no | no |
+| set | not set | yes | yes | no |
+| set | set | yes | yes | yes |
+
+### Node Startup Sequence
+
+When a new node starts with both variables set, dstack-ingress performs these steps automatically:
+
+```
+1. CNAME  node2.app.example.com → <appid2>.dstack.phala.network  (weighted, ROUTE53_INITIAL_WEIGHT)
+2. TXT    _dstack-app-address.node2.app.example.com → <appid2>:443
+3. CNAME  app.example.com → node2.app.example.com                (weight=0, SetIdentifier=node2.app.example.com)
+4. Obtain TLS cert for node2.app.example.com + app.example.com (SAN)
+```
+
+The node is fully verified and ready before step 3 introduces it to the pool. Traffic only starts flowing after an operator explicitly sets the weight above 0 in Route53.
+
+### Docker Compose Example (weighted, two-node setup)
+
+Node 1 (`node1.app.example.com`):
+
+```yaml
+services:
+  dstack-ingress:
+    image: dstacktee/dstack-ingress:20250929@sha256:2b47b3e538df0b3e7724255b89369194c8c83a7cfba64d2faf0115ad0a586458
+    restart: unless-stopped
+    ports:
+      - "443:443"
+    environment:
+      DNS_PROVIDER: route53
+      DOMAIN: node1.app.example.com
+      ALIAS_DOMAIN: app.example.com
+      GATEWAY_DOMAIN: _.dstack-prod5.phala.network
+      CERTBOT_EMAIL: ${CERTBOT_EMAIL}
+      TARGET_ENDPOINT: http://app:80
+      SET_CAA: 'true'
+      ROUTE53_INITIAL_WEIGHT: '100'
+
+      AWS_REGION: ${AWS_REGION}
+      AWS_ROLE_ARN: ${AWS_ROLE_ARN}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+    volumes:
+      - /var/run/tappd.sock:/var/run/tappd.sock
+      - cert-data:/etc/letsencrypt
+volumes:
+  cert-data:
+```
+
+Node 2 (`node2.app.example.com`) uses identical config with `DOMAIN: node2.app.example.com`. On first boot it registers itself at weight 0. To promote it, update the record weight in Route53.
+
+### Important Notes
+
+- The weight-0 CNAME for `ALIAS_DOMAIN` uses `DOMAIN` as the `SetIdentifier`, so each node has a stable, unique slot in the weighted record set that survives restarts without creating duplicates.
+- For non-Route53 providers (Cloudflare, Linode, Namecheap), `ALIAS_DOMAIN` still adds the SAN and updates nginx, but those providers do not support weighted CNAME records at the DNS level. You would need to manage traffic distribution through the provider's own load balancing features.
+- `ALIAS_DOMAIN` must be in the same Route53 hosted zone as `DOMAIN`, or at least a zone your credentials can write to.
 
 ## Migration from Cloudflare-only Setup
 

--- a/custom-domain/dstack-ingress/README.md
+++ b/custom-domain/dstack-ingress/README.md
@@ -316,7 +316,7 @@ The node is fully provisioned and verified before receiving any user traffic. Tr
 | `ALIAS_DOMAIN` | No | Public-facing domain shared across nodes (e.g. `app.example.com`) |
 | `ROUTE53_INITIAL_WEIGHT` | No | Weight for this node's primary CNAME. When combined with `ALIAS_DOMAIN`, also triggers creation of the weight-0 CNAME for the public domain. |
 
-See [DNS Provider Configuration](DNS_PROVIDERS.md#weighted-routing-with-alias_domain-route53) for a full example.
+For a complete production-ready reference that includes a dynamic nginx upstream manager (automatically enrolling and unenrolling backend containers as they start and stop), see [`docker-compose.loadbalanced.yaml`](docker-compose.loadbalanced.yaml) in this repository. For full DNS configuration details, see [DNS Provider Configuration](DNS_PROVIDERS.md#weighted-routing-with-alias_domain-route53).
 
 ## Domain Attestation and Verification
 

--- a/custom-domain/dstack-ingress/README.md
+++ b/custom-domain/dstack-ingress/README.md
@@ -184,7 +184,7 @@ configs:
 - `PROXY_BUFFERS`: Optional value for nginx `proxy_buffers` (format: `number size`, e.g. `4 256k`) in single-domain mode
 - `PROXY_BUSY_BUFFERS_SIZE`: Optional value for nginx `proxy_busy_buffers_size` (numeric with optional `k|m` suffix, e.g. `256k`) in single-domain mode
 - `CERTBOT_STAGING`: Optional; set this value to the string `true` to set the `--staging` server option on the [`certbot` cli](https://eff-certbot.readthedocs.io/en/stable/using.html#certbot-command-line-options)
-- `ALIAS_DOMAIN`: Optional; a single public-facing domain shared across multiple nodes (e.g. `app.example.com`). Added as a SAN on the TLS certificate and to nginx `server_name`. When combined with `ROUTE53_INITIAL_WEIGHT` (Route53 only), also registers a weight-0 weighted CNAME `ALIAS_DOMAIN → DOMAIN` so the node is in the pool but dark until promoted. See [Multi-Node Weighted Routing](#multi-node-weighted-routing-with-alias_domain).
+- `ALIAS_DOMAIN`: Optional; a shared domain that acts as a load-balanced entry point across multiple Phala nodes (e.g. `app.example.com`). Each node automatically joins the upstream pool on boot — users hit one address while traffic is distributed across however many nodes are running. See [Multi-Node Weighted Routing](#multi-node-weighted-routing-with-alias_domain).
 
 **Backward Compatibility:**
 
@@ -259,7 +259,7 @@ volumes:
 
 ### How It Works
 
-Each node has a **node domain** (`DOMAIN`, e.g. `node1.app.example.com`) that is the primary identity used for Phala's TXT-based app routing. A single **public domain** (`ALIAS_DOMAIN`, e.g. `app.example.com`) is shared across all nodes and used as the user-facing address.
+Each node has a **node domain** (`DOMAIN`, e.g. `node1.app.example.com`) used for its individual Phala-verified identity. Issuing certificates against per-node domains also avoids Let's Encrypt's duplicate-certificate rate limits that would occur if every node requested a cert for the same shared domain. A single **public domain** (`ALIAS_DOMAIN`, e.g. `app.example.com`) is shared across all nodes as the user-facing address and is added as a SAN on each node's certificate. The Phala gateway validates traffic to the alias domain via a shared TXT record that accumulates an entry for every node in the pool — each node appends its own `APP_ID` on boot rather than replacing the existing values.
 
 ```
                          ┌─────────────────────────────────────────┐
@@ -274,6 +274,9 @@ Users                    │         Route53 Weighted CNAMEs          │
                          │
                          │  _dstack-app-address.node1.app.example.com → <appid1>:443
                          │  _dstack-app-address.node2.app.example.com → <appid2>:443
+                         │
+                         │  _dstack-app-address.app.example.com → <appid1>:443  ← one entry per node
+                         │                                         <appid2>:443  ← appended on each boot
                          │
                          │         TLS Certificate (on each node)
                          │

--- a/custom-domain/dstack-ingress/README.md
+++ b/custom-domain/dstack-ingress/README.md
@@ -184,6 +184,7 @@ configs:
 - `PROXY_BUFFERS`: Optional value for nginx `proxy_buffers` (format: `number size`, e.g. `4 256k`) in single-domain mode
 - `PROXY_BUSY_BUFFERS_SIZE`: Optional value for nginx `proxy_busy_buffers_size` (numeric with optional `k|m` suffix, e.g. `256k`) in single-domain mode
 - `CERTBOT_STAGING`: Optional; set this value to the string `true` to set the `--staging` server option on the [`certbot` cli](https://eff-certbot.readthedocs.io/en/stable/using.html#certbot-command-line-options)
+- `ALIAS_DOMAIN`: Optional; a single public-facing domain shared across multiple nodes (e.g. `app.example.com`). Added as a SAN on the TLS certificate and to nginx `server_name`. When combined with `ROUTE53_INITIAL_WEIGHT` (Route53 only), also registers a weight-0 weighted CNAME `ALIAS_DOMAIN → DOMAIN` so the node is in the pool but dark until promoted. See [Multi-Node Weighted Routing](#multi-node-weighted-routing-with-alias_domain).
 
 **Backward Compatibility:**
 
@@ -251,6 +252,68 @@ services:
 volumes:
   cert-data:
 ```
+
+## Multi-Node Weighted Routing with ALIAS_DOMAIN
+
+`ALIAS_DOMAIN` enables a pattern where multiple independent TEE nodes share a single public-facing domain via DNS weighted routing, while each node maintains its own Phala-verified identity.
+
+### How It Works
+
+Each node has a **node domain** (`DOMAIN`, e.g. `node1.app.example.com`) that is the primary identity used for Phala's TXT-based app routing. A single **public domain** (`ALIAS_DOMAIN`, e.g. `app.example.com`) is shared across all nodes and used as the user-facing address.
+
+```
+                         ┌─────────────────────────────────────────┐
+Users                    │         Route53 Weighted CNAMEs          │
+  │                      │                                          │
+  └─► app.example.com ───┼──► node1.app.example.com  (weight=100) ─┼──► <appid1>.dstack.phala.network
+                         │                                          │
+                         └──► node2.app.example.com  (weight=0)  ──┼──► <appid2>.dstack.phala.network
+                                                                    │
+                         ┌─────────────────────────────────────────┘
+                         │         Phala Gateway TXT Routing
+                         │
+                         │  _dstack-app-address.node1.app.example.com → <appid1>:443
+                         │  _dstack-app-address.node2.app.example.com → <appid2>:443
+                         │
+                         │         TLS Certificate (on each node)
+                         │
+                         │  node1.app.example.com  ← primary
+                         │  app.example.com         ← SAN
+                         └─────────────────────────────────────────
+```
+
+### What dstack-ingress Does Automatically
+
+When `ALIAS_DOMAIN` is set:
+
+1. **Certificate** — issues a SAN cert covering both `DOMAIN` and `ALIAS_DOMAIN`, so nginx can serve TLS regardless of which hostname the client connected through.
+2. **Nginx** — adds `ALIAS_DOMAIN` to `server_name` so requests arriving via the public domain are accepted.
+3. **Weighted CNAME** *(Route53 only, requires `ROUTE53_INITIAL_WEIGHT`)* — creates a weighted CNAME record `ALIAS_DOMAIN → DOMAIN` at **weight 0**, registering this node in the pool without routing any traffic to it yet. The `SetIdentifier` is set to `DOMAIN` so each node occupies a unique, stable slot.
+
+### Lifecycle
+
+```
+Node starts
+    │
+    ├── CNAME:   node1.app.example.com → <appid>.dstack.phala.network  (weight=ROUTE53_INITIAL_WEIGHT)
+    ├── TXT:     _dstack-app-address.node1.app.example.com → <appid>:443
+    ├── CNAME:   app.example.com → node1.app.example.com               (weight=0)  ← new node, dark
+    └── CERT:    node1.app.example.com + app.example.com (SAN)
+
+Operator promotes node
+    └── Update Route53: app.example.com → node1.app.example.com weight 0 → desired weight
+```
+
+The node is fully provisioned and verified before receiving any user traffic. Traffic is enabled by a deliberate operator action (bumping the weight in Route53), not automatically.
+
+### Configuration
+
+| Variable | Required | Description |
+|---|---|---|
+| `ALIAS_DOMAIN` | No | Public-facing domain shared across nodes (e.g. `app.example.com`) |
+| `ROUTE53_INITIAL_WEIGHT` | No | Weight for this node's primary CNAME. When combined with `ALIAS_DOMAIN`, also triggers creation of the weight-0 CNAME for the public domain. |
+
+See [DNS Provider Configuration](DNS_PROVIDERS.md#weighted-routing-with-alias_domain-route53) for a full example.
 
 ## Domain Attestation and Verification
 

--- a/custom-domain/dstack-ingress/docker-compose.loadbalanced.yaml
+++ b/custom-domain/dstack-ingress/docker-compose.loadbalanced.yaml
@@ -1,0 +1,226 @@
+volumes:
+  cert-data:
+  shared_conf:
+
+services:
+  dstack-ingress:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM dstack-ingress:latest
+        RUN apt-get update && \
+            apt-get install -y --no-install-recommends inotify-tools && \
+            rm -rf /var/lib/apt/lists/*
+    restart: unless-stopped
+    volumes:
+    - /var/run/dstack.sock:/var/run/dstack.sock
+    - cert-data:/etc/letsencrypt
+    - shared_conf:/shared/conf.d
+    ports:
+    - 443:443
+    environment:
+      DNS_PROVIDER: route53
+      AWS_REGION: ${ROUTE53_AWS_REGION}
+      AWS_ROLE_ARN: ${ROUTE53_AWS_ROLE_ARN}
+      AWS_ACCESS_KEY_ID: ${ROUTE53_AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${ROUTE53_AWS_SECRET_ACCESS_KEY}
+      GATEWAY_DOMAIN: npw.${DSTACK_GATEWAY_DOMAIN}
+      CERTBOT_EMAIL: ${CERTBOT_EMAIL}
+      CERTBOT_STAGING: 'false'
+      SET_CAA: 'true'
+      PROXY_BUFFER_SIZE: 128k
+      PROXY_BUFFERS: 4 256k
+      PROXY_BUSY_BUFFERS_SIZE: 256k
+      DOMAIN: ${MACHINE_NAME}.example.com
+      ALIAS_DOMAIN: app.example.com
+      TARGET_ENDPOINT: http://dynamic_backends
+      ROUTE53_INITIAL_WEIGHT: 0
+    configs:
+      - source: nginx_master_config
+        target: /etc/nginx/nginx.conf
+      - source: nginx_fallback
+        target: /etc/nginx/conf.d/fallback.conf
+      - source: nginx_entrypoint
+        target: /nginx_entrypoint.sh
+        mode: 0755
+      - source: nginx_mainloop
+        target: /nginx_mainloop.sh
+        mode: 0755
+    networks:
+      - default
+      - my-tasks
+    entrypoint: ["/nginx_entrypoint.sh"]
+    command: []
+
+  watcher:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM python:3.11-alpine
+        RUN pip install --no-cache-dir docker
+        CMD ["python", "-u", "/watcher.py"]
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - shared_conf:/shared/conf.d
+    configs:
+      - source: watcher_py
+        target: /watcher.py
+
+configs:
+
+  nginx_master_config:
+    content: |
+      # /etc/nginx/nginx.conf
+      worker_processes auto;
+
+      events {
+          worker_connections 1024;
+      }
+
+      http {
+          include /etc/nginx/mime.types;
+          default_type application/octet-stream;
+
+          # Pull in upstream definitions
+          include /shared/conf.d/upstreams.conf;
+      
+          # Pull in server blocks
+          include /etc/nginx/conf.d/*.conf;
+      }
+
+
+  nginx_fallback:
+    content: |
+      # Internal Maintenance Fallback Server
+      server {
+          listen 127.0.0.1:9998;
+          location / {
+              add_header Content-Type text/plain;
+              return 503 "System is scaling or deploying. Please refresh in a few seconds.\n";
+          }
+      }
+      
+  nginx_entrypoint:
+    content: |
+      #!/bin/sh
+      echo "setting up upstreams.conf" >&2
+      /bin/ls -lah /shared/conf.d
+
+      # starting - so clear out any old upstreams
+      echo 'upstream dynamic_backends { server 127.0.0.1:9998; }' > /shared/conf.d/upstreams.conf
+      cat /shared/conf.d/upstreams.conf >&2
+
+      echo "execute phalas container setup" >&2
+      exec /scripts/entrypoint.sh /nginx_mainloop.sh
+
+  nginx_mainloop:
+    content: |
+      #!/bin/sh
+
+      echo "phalas container setup COMPLETE!" >&2
+      echo "start Nginx in background with server config: " >&2
+      cat /shared/conf.d/upstreams.conf >&2
+      nginx -c /etc/nginx/nginx.conf -g "daemon off; error_log /dev/stderr info;" &
+      NGINX_PID=$$!
+
+      echo "TEE Ingress started. Watching for upstream changes..."
+      # Block and watch file for atomic modifications
+      while inotifywait -q -e close_write,moved_to /shared/conf.d; do
+          echo "[$(date)] Upstream configuration updated. Reloading Nginx..."
+          nginx -s reload
+      done
+      wait $$NGINX_PID
+
+
+  # --- PYTHON WATCHER SCRIPT ---
+  watcher_py:
+    content: |
+      import docker
+      import os
+      import time
+
+      client = docker.from_env()
+      SHARED_FILE = "/shared/conf.d/upstreams.conf"
+      LABEL_KEY = "phala.ingress.target"
+      LABEL_VAL = "true"
+      TASK_NETWORK = "my-tasks"
+
+      def ensure_on_task_network(c):
+          """Attach container to the shared my-tasks network if not already on it."""
+          networks = c.attrs.get("NetworkSettings", {}).get("Networks", {})
+          # Find the network by suffix in case compose prefixes the project name
+          matched = next((k for k in networks if k.endswith(TASK_NETWORK)), None)
+          if matched:
+              print(f"  [net] {c.name} already on {matched}")
+              return matched
+          try:
+              net = client.networks.list(filters={"name": TASK_NETWORK})
+              if not net:
+                  print(f"  [net] ERROR: network '{TASK_NETWORK}' not found")
+                  return None
+              net[0].connect(c)
+              c.reload()
+              print(f"  [net] attached {c.name} to {net[0].name}")
+              # Return actual network name after attachment
+              networks = c.attrs.get("NetworkSettings", {}).get("Networks", {})
+              return next((k for k in networks if k.endswith(TASK_NETWORK)), None)
+          except Exception as e:
+              print(f"  [net] failed to attach {c.name}: {e}")
+              return None
+
+      def get_task_network_ip(c):
+          """Get the container's IP on the my-tasks network."""
+          networks = c.attrs.get("NetworkSettings", {}).get("Networks", {})
+          net_name = next((k for k in networks if k.endswith(TASK_NETWORK)), None)
+          if net_name:
+              return networks[net_name].get("IPAddress")
+          return None
+
+      def update_upstreams():
+          print("Reconciling Nginx upstream state...")
+          containers = client.containers.list(
+              filters={"label": f"{LABEL_KEY}={LABEL_VAL}", "status": "running"}
+          )
+          print(f"found {len(containers)} containers")
+
+          config = "upstream dynamic_backends {\n"
+          for c in containers:
+              net_name = ensure_on_task_network(c)
+              ip = get_task_network_ip(c) if net_name else None
+              if not ip:
+                  print(f"  [warn] skipping {c.name} — no IP on {TASK_NETWORK}")
+                  continue
+              port = c.labels.get("phala.ingress.port", "8080")
+              print(f" -> Enrolled: {c.name.lstrip('/')} on {net_name} ({ip}:{port})")
+              # Add passive health checks (fails 3 times in 15s = temporarily dead)
+              config += f"    server {ip}:{port} max_fails=3 fail_timeout=15s;\n"
+          
+          if containers:
+              config += "    server 127.0.0.1:9998 backup;\n}\n"
+          else:
+              config += "    server 127.0.0.1:9998;\n}\n"
+          
+          # Atomic write to trigger inotify cleanly
+          temp_file = f"{SHARED_FILE}.tmp"
+          with open(temp_file, "w") as f:
+              f.write(config)
+          os.replace(temp_file, SHARED_FILE)
+          print("Nginx state successfully written.\n")
+          print(f"{config}\n")
+
+      def main():
+          print("Starting Phala Python Docker Watcher...")
+          update_upstreams()
+
+          events = client.events(decode=True, filters={"type": "container", "event": ["start", "die"]})
+          for event in events:
+              attrs = event.get("Actor", {}).get("Attributes", {})
+              if attrs.get(LABEL_KEY) == LABEL_VAL:
+                  action = event.get("status")
+                  print(f"App container {action} detected!")
+                  # Slight delay ensures Docker DNS has fully registered the new container IP
+                  time.sleep(1)
+                  update_upstreams()
+
+      if __name__ == "__main__":
+          main()

--- a/custom-domain/dstack-ingress/scripts/certman.py
+++ b/custom-domain/dstack-ingress/scripts/certman.py
@@ -287,7 +287,10 @@ class CertManager:
 
         if action == "certonly":
             base_cmd.extend(["--agree-tos", "--no-eff-email",
-                            "--email", email, "-d", domain])
+                            "--email", email, "--cert-name", domain, "-d", domain])
+            alias_domain = os.environ.get("ALIAS_DOMAIN", "").strip()
+            if alias_domain:
+                base_cmd.extend(["--expand", "-d", alias_domain])
         if os.environ.get("CERTBOT_STAGING", "false") == "true":
             base_cmd.extend(["--staging"])
 

--- a/custom-domain/dstack-ingress/scripts/dns_providers/base.py
+++ b/custom-domain/dstack-ingress/scripts/dns_providers/base.py
@@ -247,6 +247,16 @@ class DNSProvider(ABC):
         )
         return self.create_dns_record(new_record)
 
+    def append_txt_record(self, name: str, content: str, ttl: int = 60) -> bool:
+        """Append a TXT value to an existing RRset without removing other values.
+
+        Used for shared alias domains where multiple instances each need their
+        APP_ID registered. Default falls back to replace behavior for providers
+        that don't support multi-value RRsets.
+        """
+        print("Note: provider does not support multi-value TXT; replacing")
+        return self.set_txt_record(name, content, ttl)
+
     def set_weighted_cname_record(
         self,
         name: str,

--- a/custom-domain/dstack-ingress/scripts/dns_providers/base.py
+++ b/custom-domain/dstack-ingress/scripts/dns_providers/base.py
@@ -247,6 +247,36 @@ class DNSProvider(ABC):
         )
         return self.create_dns_record(new_record)
 
+    def set_weighted_cname_record(
+        self,
+        name: str,
+        content: str,
+        weight: int,
+        set_identifier: str,
+        ttl: int = 60,
+    ) -> bool:
+        """Set a weighted CNAME record.
+
+        Default implementation ignores weight/set_identifier and creates a plain
+        CNAME. Providers that support weighted routing (e.g. Route53) should
+        override this method.
+
+        Args:
+            name: The record name (ALIAS_DOMAIN)
+            content: The CNAME target (primary DOMAIN)
+            weight: Routing weight (0 = registered but receives no traffic)
+            set_identifier: Unique identifier for this node in the weighted pool
+            ttl: Time to live
+
+        Returns:
+            True if successful, False otherwise
+        """
+        print(
+            f"Note: provider does not support weighted CNAMEs; "
+            f"creating plain CNAME for {name}"
+        )
+        return self.set_cname_record(name, content, ttl)
+
     def set_caa_record(
         self,
         name: str,

--- a/custom-domain/dstack-ingress/scripts/dns_providers/route53.py
+++ b/custom-domain/dstack-ingress/scripts/dns_providers/route53.py
@@ -305,6 +305,65 @@ class Route53DNSProvider(DNSProvider):
         )
         return self.create_dns_record(new_record)
 
+    def append_txt_record(self, name: str, content: str, ttl: int = 60) -> bool:
+        """Append to a TXT RRset — fetches all existing values and UPSERTs the full set."""
+        hosted_zone_id = self._ensure_hosted_zone_id(name)
+        if not hosted_zone_id:
+            return False
+
+        normalized_name = self._normalize_record_name(name)
+        quoted_content = f'"{content}"'
+
+        # Fetch existing TXT RRset directly — get_dns_records only returns the first value
+        paginator = self.client.get_paginator("list_resource_record_sets")
+        existing_rrset = None
+        try:
+            for page in paginator.paginate(HostedZoneId=hosted_zone_id):
+                for record_set in page["ResourceRecordSets"]:
+                    if record_set["Name"] == normalized_name and record_set["Type"] == "TXT":
+                        existing_rrset = record_set
+                        break
+                if existing_rrset:
+                    break
+        except Exception as e:
+            print(f"Error fetching existing TXT records: {e}", file=sys.stderr)
+            return False
+
+        existing_values = []
+        if existing_rrset:
+            existing_values = [rr["Value"] for rr in existing_rrset.get("ResourceRecords", [])]
+            ttl = existing_rrset.get("TTL", ttl)
+
+        if quoted_content in existing_values:
+            print(f"TXT record already contains {content}")
+            return True
+
+        all_values = existing_values + [quoted_content]
+        print(f"Appending TXT value for {name}: {len(all_values)} total entries")
+
+        change_batch = {
+            "Changes": [
+                {
+                    "Action": "UPSERT",
+                    "ResourceRecordSet": {
+                        "Name": normalized_name,
+                        "Type": "TXT",
+                        "TTL": ttl,
+                        "ResourceRecords": [{"Value": v} for v in all_values],
+                    },
+                }
+            ]
+        }
+
+        try:
+            response = self.client.change_resource_record_sets(
+                HostedZoneId=hosted_zone_id, ChangeBatch=change_batch
+            )
+            return response.get("ChangeInfo", {}).get("Status") in ["PENDING", "INSYNC"]
+        except Exception as e:
+            print(f"Error appending TXT record: {e}", file=sys.stderr)
+            return False
+
     def create_dns_record(self, record: DNSRecord) -> bool:
         """
         Create a DNS record.

--- a/custom-domain/dstack-ingress/scripts/dns_providers/route53.py
+++ b/custom-domain/dstack-ingress/scripts/dns_providers/route53.py
@@ -224,6 +224,7 @@ class Route53DNSProvider(DNSProvider):
         want_weight = int(env_weight) if env_weight and env_weight.isdigit() else None
 
         existing_records = self.get_dns_records(name, RecordType.CNAME)
+        record_to_replace = None
         for record in existing_records:
             if record.content == content:
                 has_weight = record.data and "weight" in record.data
@@ -234,15 +235,17 @@ class Route53DNSProvider(DNSProvider):
                     print("Weighted CNAME record with the same content and weight already exists")
                     return True
                 # Weight config mismatch — delete existing record before upserting,
-        # because Route53 forbids mixing weighted and non-weighted RRSets
-        # with the same name and type.
-        has_weight = record.data and "weight" in record.data
-        if (want_weight is not None and not has_weight) or (want_weight is None and has_weight):
+                # because Route53 forbids mixing weighted and non-weighted RRSets
+                # with the same name and type.
+                record_to_replace = record
+                break
+        if record_to_replace is not None:
+            has_weight = record_to_replace.data and "weight" in record_to_replace.data
             print(
                 f"Deleting existing {'non-weighted' if not has_weight else 'weighted'} "
                 f"CNAME before creating {'weighted' if want_weight is not None else 'non-weighted'} one"
             )
-            if not self.delete_dns_record(record.id, name):
+            if not self.delete_dns_record(record_to_replace.id, name):
                 print(f"Error: Failed to delete existing CNAME record", file=sys.stderr)
                 return False
 
@@ -253,6 +256,52 @@ class Route53DNSProvider(DNSProvider):
             content=content,
             ttl=ttl,
             proxied=proxied,
+        )
+        return self.create_dns_record(new_record)
+
+    def set_weighted_cname_record(
+        self,
+        name: str,
+        content: str,
+        weight: int,
+        set_identifier: str,
+        ttl: int = 60,
+    ) -> bool:
+        """Create or update a weighted CNAME record with an explicit weight.
+
+        Unlike set_alias_record, this bypasses ROUTE53_INITIAL_WEIGHT and uses
+        the provided weight directly. set_identifier should be the primary node
+        domain so each node occupies a unique slot in the weighted pool.
+        """
+        existing_records = self.get_dns_records(name, RecordType.CNAME)
+        for record in existing_records:
+            if record.data and record.data.get("set_identifier") == set_identifier:
+                if record.content == content and record.data.get("weight") == weight:
+                    print(
+                        f"Weighted CNAME for {name} "
+                        f"(id={set_identifier}, weight={weight}) already exists"
+                    )
+                    return True
+                # Same identifier, different weight or content — delete and recreate
+                print(
+                    f"Updating weighted CNAME for {name} "
+                    f"(id={set_identifier}) to weight={weight}"
+                )
+                if record.id and not self.delete_dns_record(record.id, name):
+                    print(
+                        f"Error: Failed to delete existing weighted CNAME",
+                        file=sys.stderr,
+                    )
+                    return False
+                break
+
+        new_record = DNSRecord(
+            id=None,
+            name=name,
+            type=RecordType.CNAME,
+            content=content,
+            ttl=ttl,
+            data={"weight": weight, "set_identifier": set_identifier},
         )
         return self.create_dns_record(new_record)
 

--- a/custom-domain/dstack-ingress/scripts/dns_providers/route53.py
+++ b/custom-domain/dstack-ingress/scripts/dns_providers/route53.py
@@ -218,6 +218,44 @@ class Route53DNSProvider(DNSProvider):
             print(f"Error getting DNS records: {e}", file=sys.stderr)
             return []
 
+    def set_alias_record(self, name: str, content: str, ttl: int = 60, proxied: bool = False) -> bool:
+        """Override to handle weighted routing: re-create if weight config changed."""
+        env_weight = os.getenv("ROUTE53_INITIAL_WEIGHT")
+        want_weight = int(env_weight) if env_weight and env_weight.isdigit() else None
+
+        existing_records = self.get_dns_records(name, RecordType.CNAME)
+        for record in existing_records:
+            if record.content == content:
+                has_weight = record.data and "weight" in record.data
+                if want_weight is None and not has_weight:
+                    print("CNAME record with the same content already exists")
+                    return True
+                if want_weight is not None and has_weight and record.data["weight"] == want_weight:
+                    print("Weighted CNAME record with the same content and weight already exists")
+                    return True
+                # Weight config mismatch — delete existing record before upserting,
+        # because Route53 forbids mixing weighted and non-weighted RRSets
+        # with the same name and type.
+        has_weight = record.data and "weight" in record.data
+        if (want_weight is not None and not has_weight) or (want_weight is None and has_weight):
+            print(
+                f"Deleting existing {'non-weighted' if not has_weight else 'weighted'} "
+                f"CNAME before creating {'weighted' if want_weight is not None else 'non-weighted'} one"
+            )
+            if not self.delete_dns_record(record.id, name):
+                print(f"Error: Failed to delete existing CNAME record", file=sys.stderr)
+                return False
+
+        new_record = DNSRecord(
+            id=None,
+            name=name,
+            type=RecordType.CNAME,
+            content=content,
+            ttl=ttl,
+            proxied=proxied,
+        )
+        return self.create_dns_record(new_record)
+
     def create_dns_record(self, record: DNSRecord) -> bool:
         """
         Create a DNS record.

--- a/custom-domain/dstack-ingress/scripts/dnsman.py
+++ b/custom-domain/dstack-ingress/scripts/dnsman.py
@@ -14,7 +14,7 @@ def main():
     )
     parser.add_argument(
         "action",
-        choices=["set_cname", "set_alias", "set_txt", "set_caa", "set_weighted_cname"],
+        choices=["set_cname", "set_alias", "set_txt", "set_txt_append", "set_caa", "set_weighted_cname"],
         help="Action to perform",
     )
     parser.add_argument("--domain", required=True, help="Domain name")
@@ -73,6 +73,17 @@ def main():
                 print(f"Failed to set TXT record for {args.domain}", file=sys.stderr)
                 sys.exit(1)
             print(f"Successfully set TXT record for {args.domain}")
+
+        elif args.action == "set_txt_append":
+            if not args.content:
+                print("Error: --content is required for TXT records", file=sys.stderr)
+                sys.exit(1)
+
+            success = provider.append_txt_record(args.domain, args.content)
+            if not success:
+                print(f"Failed to append TXT record for {args.domain}", file=sys.stderr)
+                sys.exit(1)
+            print(f"Successfully appended TXT record for {args.domain}")
 
         elif args.action == "set_weighted_cname":
             if not args.content:

--- a/custom-domain/dstack-ingress/scripts/dnsman.py
+++ b/custom-domain/dstack-ingress/scripts/dnsman.py
@@ -14,7 +14,7 @@ def main():
     )
     parser.add_argument(
         "action",
-        choices=["set_cname", "set_alias", "set_txt", "set_caa"],
+        choices=["set_cname", "set_alias", "set_txt", "set_caa", "set_weighted_cname"],
         help="Action to perform",
     )
     parser.add_argument("--domain", required=True, help="Domain name")
@@ -27,6 +27,13 @@ def main():
         "--caa-tag", choices=["issue", "issuewild", "iodef"], help="CAA record tag"
     )
     parser.add_argument("--caa-value", help="CAA record value")
+    parser.add_argument(
+        "--weight", type=int, help="Routing weight for weighted CNAME records"
+    )
+    parser.add_argument(
+        "--set-identifier",
+        help="Unique identifier for this record in a weighted record set",
+    )
 
     args = parser.parse_args()
 
@@ -66,6 +73,31 @@ def main():
                 print(f"Failed to set TXT record for {args.domain}", file=sys.stderr)
                 sys.exit(1)
             print(f"Successfully set TXT record for {args.domain}")
+
+        elif args.action == "set_weighted_cname":
+            if not args.content:
+                print(
+                    "Error: --content is required for weighted CNAME records",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            if args.weight is None:
+                print(
+                    "Error: --weight is required for weighted CNAME records",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            set_identifier = args.set_identifier or args.domain
+            success = provider.set_weighted_cname_record(
+                args.domain, args.content, args.weight, set_identifier
+            )
+            if not success:
+                print(
+                    f"Failed to set weighted CNAME record for {args.domain}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            print(f"Successfully set weighted CNAME record for {args.domain}")
 
         elif args.action == "set_caa":
             if not args.caa_tag or not args.caa_value:

--- a/custom-domain/dstack-ingress/scripts/entrypoint.sh
+++ b/custom-domain/dstack-ingress/scripts/entrypoint.sh
@@ -40,6 +40,9 @@ fi
 if ! TXT_PREFIX=$(sanitize_dns_label "$TXT_PREFIX"); then
     exit 1
 fi
+if ! ALIAS_DOMAIN=$(sanitize_domain "$ALIAS_DOMAIN"); then
+    exit 1
+fi
 
 PROXY_CMD="proxy"
 if [[ "${TARGET_ENDPOINT}" == grpc://* ]]; then
@@ -141,11 +144,16 @@ setup_nginx_conf() {
         proxy_busy_buffers_size_conf="    proxy_busy_buffers_size ${PROXY_BUSY_BUFFERS_SIZE};"
     fi
 
+    local server_name_value="${DOMAIN}"
+    if [ -n "$ALIAS_DOMAIN" ]; then
+        server_name_value="${DOMAIN} ${ALIAS_DOMAIN}"
+    fi
+
     cat <<EOF >/etc/nginx/conf.d/default.conf
 server {
     listen ${PORT} ssl;
     http2 on;
-    server_name ${DOMAIN};
+    server_name ${server_name_value};
 
     # SSL certificate configuration
     ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
@@ -241,6 +249,26 @@ set_txt_record() {
     fi
 }
 
+set_alias_domain_cname() {
+    local node_domain="$1"
+
+    if [ -z "$ALIAS_DOMAIN" ] || [ -z "$ROUTE53_INITIAL_WEIGHT" ]; then
+        return
+    fi
+
+    echo "Setting weight-0 weighted CNAME: $ALIAS_DOMAIN -> $node_domain"
+    dnsman.py set_weighted_cname \
+        --domain "$ALIAS_DOMAIN" \
+        --content "$node_domain" \
+        --weight 0 \
+        --set-identifier "$node_domain"
+
+    if [ $? -ne 0 ]; then
+        echo "Warning: Failed to set weighted CNAME for $ALIAS_DOMAIN -> $node_domain"
+        echo "You may need to create this record manually"
+    fi
+}
+
 set_caa_record() {
     local domain="$1"
     if [ "$SET_CAA" != "true" ]; then
@@ -277,6 +305,7 @@ process_domain() {
 
     set_alias_record "$domain"
     set_txt_record "$domain"
+    set_alias_domain_cname "$domain"
     renew-certificate.sh "$domain" || echo "First certificate renewal failed for $domain, will retry after set CAA record"
     set_caa_record "$domain"
     renew-certificate.sh "$domain"

--- a/custom-domain/dstack-ingress/scripts/entrypoint.sh
+++ b/custom-domain/dstack-ingress/scripts/entrypoint.sh
@@ -247,6 +247,17 @@ set_txt_record() {
         echo "Error: Failed to set TXT record for $domain"
         exit 1
     fi
+
+    # Also register APP_ID for alias domain (append-mode to support multiple instances)
+    if [ -n "$ALIAS_DOMAIN" ]; then
+        dnsman.py set_txt_append \
+            --domain "${TXT_PREFIX}.${ALIAS_DOMAIN}" \
+            --content "$APP_ID:$PORT"
+        if [ $? -ne 0 ]; then
+            echo "Warning: Failed to append TXT record for alias domain $ALIAS_DOMAIN"
+            # Non-fatal: node routing still works; alias routing may be degraded
+        fi
+    fi
 }
 
 set_alias_domain_cname() {


### PR DESCRIPTION
# PR: Multi-Node Weighted Routing + ALIAS_DOMAIN Support

## Overview

This PR introduces `ALIAS_DOMAIN` — a shared domain that acts as a load-balanced entry point across multiple Phala nodes. Each node automatically joins the upstream pool on boot, so users hit one address while traffic is distributed across however many nodes are running. It also includes two unrelated fixes: a certbot staging/production switch bug and a GHCR manifest check header fix.

A complete production-ready reference compose file with a dynamic nginx upstream manager is included at [`docker-compose.loadbalanced.yaml`](docker-compose.loadbalanced.yaml).

---

## Feature: ALIAS_DOMAIN + Weighted Routing (Route53)

### Motivation

Previously, each `dstack-ingress` node only managed DNS for its own `DOMAIN`. To run multiple nodes behind a single user-facing address you had to manually manage all the DNS wiring. This PR automates that pattern.

Each node has a **node domain** (`DOMAIN`, e.g. `node1.app.example.com`) used for its individual Phala-verified identity. Keeping certs per-node also avoids Let's Encrypt's duplicate-certificate rate limits that would occur if every node requested a cert for the same shared domain. A single **alias domain** (`ALIAS_DOMAIN`, e.g. `app.example.com`) is shared across all nodes as the user-facing address and is added as a SAN on each node's certificate.

### What gets automated on boot

When `ALIAS_DOMAIN` is set, each node now automatically:

1. **TLS cert** — Issues a SAN cert covering both `DOMAIN` and `ALIAS_DOMAIN`, so nginx accepts TLS connections on either hostname (`certman.py`).
2. **Nginx** — Adds `ALIAS_DOMAIN` to `server_name` so requests arriving via the public domain are served (`entrypoint.sh`).
3. **Alias TXT record** — Appends this node's `APP_ID:PORT` to `_dstack-app-address.{ALIAS_DOMAIN}` in **append mode**, not replace mode (see below). The Phala gateway looks up this record directly to validate traffic (`entrypoint.sh`, `dnsman.py`, `base.py`, `route53.py`).
4. **Weight-0 weighted CNAME** *(Route53 only, requires `ROUTE53_INITIAL_WEIGHT`)* — Creates a `ALIAS_DOMAIN → DOMAIN` weighted CNAME at weight 0 using `DOMAIN` as the `SetIdentifier`. The node is registered in the pool but receives no traffic until an operator bumps the weight in Route53 (`entrypoint.sh`, `dnsman.py`, `route53.py`).

### Resulting DNS layout (two-node example)

```
app.example.com    CNAME (w=100, id=node1.app.example.com) → node1.app.example.com
app.example.com    CNAME (w=0,   id=node2.app.example.com) → node2.app.example.com  ← new, dark

node1.app.example.com  CNAME → <appid1>.dstack-prod5.phala.network
node2.app.example.com  CNAME → <appid2>.dstack-prod5.phala.network

_dstack-app-address.node1.app.example.com  TXT  "<appid1>:443"
_dstack-app-address.node2.app.example.com  TXT  "<appid2>:443"
_dstack-app-address.app.example.com        TXT  "<appid1>:443"
                                                 "<appid2>:443"  ← multi-value RRset
```

### Why append-mode TXT matters

`set_txt_record` deletes all existing TXT values before writing a new one. With two nodes sharing `ALIAS_DOMAIN`, node 2 would overwrite node 1's `APP_ID` and break gateway routing for node 1. The new `append_txt_record` fetches the existing Route53 TXT RRset, appends the new value, and UPSERTs the full merged set in one call — so both `APP_ID`s coexist.

For non-Route53 providers, `append_txt_record` falls back to replace semantics (with a warning), since those providers don't expose a multi-value TXT API.

**Known limitation:** there is no deregistration. When a node goes down, its `APP_ID` stays in the TXT RRset. The operator must zero out the node's weighted CNAME weight in Route53 to stop gateway routing attempts to the dead node.

### New env vars

| Variable | Effect |
|---|---|
| `ALIAS_DOMAIN` | Adds SAN to cert, adds to nginx `server_name`, appends alias TXT, optionally creates weight-0 weighted CNAME (if `ROUTE53_INITIAL_WEIGHT` is also set) |
| `ROUTE53_INITIAL_WEIGHT` | Weight applied to this node's primary CNAME (`DOMAIN → gateway`). When combined with `ALIAS_DOMAIN`, also triggers creation of the weight-0 `ALIAS_DOMAIN → DOMAIN` CNAME |

### `route53.py` — why such a large diff?

Route53's weighted routing model is fundamentally different from standard DNS and required changes at every layer of the provider. Here's why each piece was touched:

**`get_dns_records` — weighted record awareness**

The original implementation discarded `Weight` and `SetIdentifier` from API responses and used a flat `name:type` string as the record ID. This meant two weighted CNAMEs for the same name (e.g. `app.example.com → node1` and `app.example.com → node2`) were indistinguishable — you couldn't delete or update one without affecting the other. The record ID format is now `name:type:set_identifier` for weighted records, and `Weight`/`SetIdentifier` are preserved in `DNSRecord.data`.

**`set_alias_record` override — weighted/non-weighted coexistence**

Route53 rejects a `UPSERT` that would mix weighted and non-weighted records under the same name and type. If a node previously ran without `ROUTE53_INITIAL_WEIGHT` and is restarted with it set (or vice versa), the existing record must be deleted before the new one can be created. This override detects that mismatch and handles the delete-then-create transparently.

**`set_weighted_cname_record` — explicit weighted slot management**

The `ALIAS_DOMAIN → DOMAIN` weight-0 CNAME needs to be created with a specific `SetIdentifier` (the node's `DOMAIN`) so each node occupies a stable, unique slot in the weighted pool that survives restarts without creating duplicates. This method bypasses `ROUTE53_INITIAL_WEIGHT` and takes weight and identifier as explicit arguments.

**`create_dns_record` — automatic weight injection**

Rather than requiring every call site to pass weight parameters, `create_dns_record` reads `ROUTE53_INITIAL_WEIGHT` and injects `Weight`/`SetIdentifier` automatically for non-TXT records. TXT records are explicitly excluded — certbot challenge records and app-address TXT records must never be weighted. If no `SetIdentifier` is provided in `record.data`, an `auto-{timestamp}` value is generated to avoid collisions.

**`delete_dns_record` — targeted deletion for weighted records**

Previously used `name:type` as the lookup key, which would match the first record of that type regardless of `SetIdentifier`. With multiple weighted CNAMEs under the same name, this would delete the wrong node's record. The format is now `name:type:set_identifier` and the lookup explicitly matches `SetIdentifier` when present.

**`append_txt_record` — multi-value TXT UPSERT**

Described above. Implemented here rather than via `get_dns_records` + `create_dns_record` because `get_dns_records` only returns the first `ResourceRecord` value per RRset — fetching all existing values requires a direct paginator call against the raw API response.

---

## Fix: certbot staging/production switch (`certman.py`)

> **Note for reviewer:** PR #81 addressed a related certbot bug in this file and its changes are visible in `main`. The changes below are distinct from PR #81 — see the breakdown at the end of this section.

### `acme_account_exists()`

Added a new method that checks whether a Let's Encrypt ACME account exists for the currently configured server (staging vs. production). The account directory differs between the two, so after a staging→production switch the certificate file persists on the volume but the account is gone.

Previously, `run_action` would see the existing cert and call `renew_certificate` — which would fail because there was no account to renew with. Now it also checks `acme_account_exists()`, and if the cert exists but the account is missing it falls through to `obtain_certificate` instead and logs a clear message explaining the situation.

### `renew_certificate` dead code removal

PR #81 correctly added a "No renewals were attempted" check inside the `returncode == 0` branch (now at line ~399 in main). However, it left behind the original unreachable copy of that check at line ~413 — after a `return False, False` that made it impossible to reach. This branch removes that leftover dead code and the now-redundant `print("Certificate renewed successfully")` / `return True, True` that followed it.

### `--cert-name` flag

Added `--cert-name {domain}` to the certbot `certonly` command so the certificate is always stored at `/etc/letsencrypt/live/{domain}/` regardless of whether `--expand` changes the primary domain order on pre-existing certs.

### Relationship to PR #81

| Change | In main (PR #81)? | This branch? |
|---|---|---|
| "No renewals" check inside `returncode == 0` block | Yes | No (already absorbed) |
| Dead "No renewals" copy removed from unreachable code | No — left behind | Yes |
| `acme_account_exists()` + `run_action` check | No | Yes |
| `--cert-name` flag | No | Yes |
| `ALIAS_DOMAIN` SAN support (`--expand -d`) | No | Yes |

---

## Fix: GHCR manifest check in `prelaunch.sh`

The `curl` call that validates GHCR pull access was missing `Accept` headers for OCI and Docker manifest types. Without them, some registries return non-200 even for valid images. Added the standard multi-format `Accept` header. Version bumped to `v0.0.14`.

---

## Files changed

| File | Summary |
|---|---|
| `scripts/entrypoint.sh` | `ALIAS_DOMAIN` sanitization; nginx `server_name` update; alias TXT append call; new `set_alias_domain_cname()` function |
| `scripts/certman.py` | SAN support for `ALIAS_DOMAIN`; `acme_account_exists()`; fixed renewal logic order; added `--cert-name` |
| `scripts/dns_providers/base.py` | New `append_txt_record()` (fallback to replace); new `set_weighted_cname_record()` (fallback to plain CNAME) |
| `scripts/dns_providers/route53.py` | Weighted routing in `get_dns_records`, `create_dns_record`, `delete_dns_record`; new `set_alias_record()`, `set_weighted_cname_record()`, `append_txt_record()` overrides |
| `scripts/dnsman.py` | Added `set_txt_append`, `set_weighted_cname` actions; added `--weight`, `--set-identifier` flags |
| `Dockerfile` | Added `ENV PYTHONUNBUFFERED=1` |
| `DNS_PROVIDERS.md` | Full documentation for `ALIAS_DOMAIN`, `ROUTE53_INITIAL_WEIGHT`, weighted routing pattern, updated docker-compose examples |
| `README.md` | New "Multi-Node Weighted Routing" section; `ALIAS_DOMAIN` env var entry |
| `docker-compose.loadbalanced.yaml` | Complete reference compose file: dstack-ingress with `ALIAS_DOMAIN` + weighted routing, plus a Python watcher that dynamically manages nginx upstream pool membership as backend containers start and stop |
| `phala-cloud-prelaunch-script/prelaunch.sh` | GHCR manifest `Accept` header fix; version bump to v0.0.14 |