### PR TITLE
Pin dstack-ingress image to v2.0 digest

### DIFF
--- a/custom-domain/dstack-ingress/README.md
+++ b/custom-domain/dstack-ingress/README.md
@@ -35,7 +35,7 @@ You can use a wildcard domain (e.g. `*.myapp.com`) to route all subdomains to a 
 ```yaml
 services:
   dstack-ingress:
-    image: dstacktee/dstack-ingress:latest
+    image: dstacktee/dstack-ingress:2.0@sha256:9fb13c42dceaba91d2e2e7de3a06700a2cf507f4335ae70f3f1db4574a5ad552
     ports:
       - "443:443"
     environment:
@@ -64,7 +64,7 @@ volumes:
 ```yaml
 services:
   dstack-ingress:
-    image: dstacktee/dstack-ingress:latest
+    image: dstacktee/dstack-ingress:2.0@sha256:9fb13c42dceaba91d2e2e7de3a06700a2cf507f4335ae70f3f1db4574a5ad552
     ports:
       - "443:443"
     environment:
@@ -102,7 +102,7 @@ Use `ROUTING_MAP` to route different domains to different backends via SNI:
 ```yaml
 services:
   ingress:
-    image: dstacktee/dstack-ingress:latest
+    image: dstacktee/dstack-ingress:2.0@sha256:9fb13c42dceaba91d2e2e7de3a06700a2cf507f4335ae70f3f1db4574a5ad552
     ports:
       - "443:443"
     environment:

--- a/custom-domain/dstack-ingress/docker-compose.multi.yaml
+++ b/custom-domain/dstack-ingress/docker-compose.multi.yaml
@@ -1,7 +1,6 @@
 services:
   ingress:
-    # TODO: pin by digest for production (dstacktee/dstack-ingress@sha256:...)
-    image: dstacktee/dstack-ingress:latest
+    image: dstacktee/dstack-ingress:2.0@sha256:9fb13c42dceaba91d2e2e7de3a06700a2cf507f4335ae70f3f1db4574a5ad552
     ports:
       - "443:443"
     environment:

--- a/custom-domain/dstack-ingress/docker-compose.yaml
+++ b/custom-domain/dstack-ingress/docker-compose.yaml
@@ -1,7 +1,6 @@
 services:
   dstack-ingress:
-    # TODO: pin by digest for production (dstacktee/dstack-ingress@sha256:...)
-    image: dstacktee/dstack-ingress:latest
+    image: dstacktee/dstack-ingress:2.0@sha256:9fb13c42dceaba91d2e2e7de3a06700a2cf507f4335ae70f3f1db4574a5ad552
     ports:
       - "443:443"
     environment:


### PR DESCRIPTION
## Summary

- Pin `dstacktee/dstack-ingress` image to `2.0@sha256:9fb13c42dceaba91d2e2e7de3a06700a2cf507f4335ae70f3f1db4574a5ad552` in all example docker-compose files and README
- Remove TODO comments about pinning

## Test plan

- [x] Verify digest matches the image built by the `dstack-ingress-v2.0` tag release workflow