### PR TITLE
fix: dstack-ingress 2.1 — wildcard cert + evidence latency

### DIFF
--- a/custom-domain/dstack-ingress/README.md
+++ b/custom-domain/dstack-ingress/README.md
@@ -35,7 +35,7 @@ You can use a wildcard domain (e.g. `*.myapp.com`) to route all subdomains to a 
 ```yaml
 services:
   dstack-ingress:
-    image: dstacktee/dstack-ingress:2.0@sha256:9fb13c42dceaba91d2e2e7de3a06700a2cf507f4335ae70f3f1db4574a5ad552
+    image: dstacktee/dstack-ingress:2.1
     ports:
       - "443:443"
     environment:
@@ -64,7 +64,7 @@ volumes:
 ```yaml
 services:
   dstack-ingress:
-    image: dstacktee/dstack-ingress:2.0@sha256:9fb13c42dceaba91d2e2e7de3a06700a2cf507f4335ae70f3f1db4574a5ad552
+    image: dstacktee/dstack-ingress:2.1
     ports:
       - "443:443"
     environment:
@@ -102,7 +102,7 @@ Use `ROUTING_MAP` to route different domains to different backends via SNI:
 ```yaml
 services:
   ingress:
-    image: dstacktee/dstack-ingress:2.0@sha256:9fb13c42dceaba91d2e2e7de3a06700a2cf507f4335ae70f3f1db4574a5ad552
+    image: dstacktee/dstack-ingress:2.1
     ports:
       - "443:443"
     environment:

--- a/custom-domain/dstack-ingress/docker-compose.multi.yaml
+++ b/custom-domain/dstack-ingress/docker-compose.multi.yaml
@@ -1,6 +1,6 @@
 services:
   ingress:
-    image: dstacktee/dstack-ingress:2.0@sha256:9fb13c42dceaba91d2e2e7de3a06700a2cf507f4335ae70f3f1db4574a5ad552
+    image: dstacktee/dstack-ingress:2.1
     ports:
       - "443:443"
     environment:

--- a/custom-domain/dstack-ingress/docker-compose.yaml
+++ b/custom-domain/dstack-ingress/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   dstack-ingress:
-    image: dstacktee/dstack-ingress:2.0@sha256:9fb13c42dceaba91d2e2e7de3a06700a2cf507f4335ae70f3f1db4574a5ad552
+    image: dstacktee/dstack-ingress:2.1
     ports:
       - "443:443"
     environment:

--- a/custom-domain/dstack-ingress/scripts/build-combined-pems.sh
+++ b/custom-domain/dstack-ingress/scripts/build-combined-pems.sh
@@ -4,6 +4,8 @@
 
 set -e
 
+source /scripts/functions.sh
+
 CERT_DIR="/etc/haproxy/certs"
 mkdir -p "$CERT_DIR"
 
@@ -11,7 +13,7 @@ all_domains=$(get-all-domains.sh)
 
 while IFS= read -r domain; do
     [[ -n "$domain" ]] || continue
-    le_dir="/etc/letsencrypt/live/${domain}"
+    le_dir="/etc/letsencrypt/live/$(cert_dir_name "$domain")"
     combined="${CERT_DIR}/${domain}.pem"
     if [ -f "${le_dir}/fullchain.pem" ] && [ -f "${le_dir}/privkey.pem" ]; then
         cat "${le_dir}/fullchain.pem" "${le_dir}/privkey.pem" > "$combined"

--- a/custom-domain/dstack-ingress/scripts/entrypoint.sh
+++ b/custom-domain/dstack-ingress/scripts/entrypoint.sh
@@ -155,9 +155,13 @@ EOF
     if [ "$EVIDENCE_SERVER" = "true" ]; then
         cat <<'EVIDENCE_BLOCK' >>/etc/haproxy/haproxy.cfg
 
-    # Route /evidences requests to local evidence HTTP server
+    # Route /evidences requests to the local evidence HTTP server.
+    # inspect-delay sets the upper bound for buffering; the accept rule
+    # fires as soon as any application data is present in the buffer
+    # (after SSL termination a full TLS record is decrypted atomically,
+    # so the complete HTTP request is available on first evaluation).
     tcp-request inspect-delay 5s
-    tcp-request content accept if WAIT_END
+    tcp-request content accept if { req.len gt 0 }
     acl is_evidence payload(0,0) -m beg "GET /evidences"
     acl is_evidence payload(0,0) -m beg "HEAD /evidences"
     use_backend be_evidence if is_evidence


### PR DESCRIPTION
## Summary

Two bug fixes for dstack-ingress, bumping to version 2.1:

- **Wildcard certificate lookup**: `build-combined-pems.sh` looked for `/etc/letsencrypt/live/*.example.com/` but certbot stores wildcard certs under `/etc/letsencrypt/live/example.com/`. Fixed by using the existing `cert_dir_name()` helper from `functions.sh` to strip the `*.` prefix.

- **5-second latency on all traffic**: The HAProxy evidence-server routing used `tcp-request content accept if WAIT_END`, which forces HAProxy to wait the full `inspect-delay 5s` before accepting **every** new TLS connection. Replaced with `tcp-request content accept if { req.len gt 0 }` — accepts as soon as any application data arrives. After SSL termination, a complete TLS record is decrypted atomically so the full HTTP request is always available on first evaluation.

## Test plan

Both fixes verified on a live Phala Cloud CVM:

- [x] Wildcard cert (`*.dstack-k3s.t16z.com`) correctly obtained and served by HAProxy
- [x] Normal HTTPS traffic: ~0.25s (was 5.2s with `WAIT_END`)
- [x] Evidence endpoint (`/evidences/`, `/evidences/quote.json`): ~0.25s, HTTP 200
- [x] Three consecutive fresh-connection requests all fast (no first-request penalty)

## Release

After merge, tag `dstack-ingress-v2.1` to trigger CI image build → `dstacktee/dstack-ingress:2.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)