### PR TITLE
fix(ingress): eliminate 5s latency from HAProxy evidence routing

### DIFF
--- a/custom-domain/dstack-ingress/scripts/entrypoint.sh
+++ b/custom-domain/dstack-ingress/scripts/entrypoint.sh
@@ -156,14 +156,16 @@ EOF
         cat <<'EVIDENCE_BLOCK' >>/etc/haproxy/haproxy.cfg
 
     # Route /evidences requests to the local evidence HTTP server.
-    # inspect-delay sets the upper bound for buffering; the accept rule
-    # fires as soon as any application data is present in the buffer
-    # (after SSL termination a full TLS record is decrypted atomically,
-    # so the complete HTTP request is available on first evaluation).
+    # accept fires once 16 bytes have arrived — enough for the
+    # longest prefix we match ("HEAD /evidences" = 16 chars).
+    # Using req.len with a concrete threshold is critical: the
+    # previous payload(0,0) (length 0 = "whole buffer") deferred
+    # evaluation until the full inspect-delay because HAProxy
+    # cannot know when a TCP stream ends.
     tcp-request inspect-delay 5s
-    tcp-request content accept if { req.len gt 0 }
-    acl is_evidence payload(0,0) -m beg "GET /evidences"
-    acl is_evidence payload(0,0) -m beg "HEAD /evidences"
+    tcp-request content accept if { req.len ge 16 }
+    acl is_evidence payload(0,16) -m beg "GET /evidences"
+    acl is_evidence payload(0,16) -m beg "HEAD /evidences"
     use_backend be_evidence if is_evidence
 EVIDENCE_BLOCK
     fi


### PR DESCRIPTION
## Summary

- **Fix 5-second per-request latency** caused by HAProxy's `payload(0,0)` deferring TCP content inspection until the full `inspect-delay` timer expires
- Change `payload(0,0)` to `payload(0,16)` and `req.len gt 0` to `req.len ge 16` so HAProxy evaluates the evidence routing ACL as soon as 16 bytes arrive (enough for `"HEAD /evidences"`)

## Root Cause

In TCP mode, `payload(0,0)` with length 0 means "extract from offset 0 to the end of the buffer." Because HAProxy cannot know when a TCP stream ends, it waits for the full `inspect-delay` (5s) before evaluating the rule — adding 5 seconds of latency to **every** proxied request, not just `/evidences`.

The previous fix (commit 66abdd9) changed `WAIT_END` to `req.len gt 0`, which correctly unblocked the `accept` rule, but left `payload(0,0)` in the ACL conditions. Since the `accept` rule fires first (any data present → accept → stop inspecting), the `payload(0,0)` in the ACL lines was still evaluated and caused the same deferral.

## Fix

```diff
-    tcp-request content accept if { req.len gt 0 }
-    acl is_evidence payload(0,0) -m beg "GET /evidences"
-    acl is_evidence payload(0,0) -m beg "HEAD /evidences"
+    tcp-request content accept if { req.len ge 16 }
+    acl is_evidence payload(0,16) -m beg "GET /evidences"
+    acl is_evidence payload(0,16) -m beg "HEAD /evidences"
```

- `req.len ge 16`: wait until at least 16 bytes are buffered (the longest prefix we match: `"HEAD /evidences"` = 16 chars), then accept — stops further inspection immediately
- `payload(0,16)`: extract exactly 16 bytes from the start instead of the unbounded `payload(0,0)`, so the ACL can be evaluated without waiting for stream end

## Test Results

Verified on a live CVM deployment (Route53 + Phala gateway):

| Metric | Before | After |
|--------|--------|-------|
| Time to first byte | ~5.2s | ~0.28s |
| `/evidences` routing | Working | Working |

## Test plan

- [x] HAProxy config syntax validated with `haproxy -c`
- [x] Deployed to live CVM and confirmed latency drop (5.2s → 0.28s)
- [x] Verified `/evidences` endpoint still routes correctly after fix
- [x] Tested with both single-domain and evidence server modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)