### PR TITLE
tsm-shim: make inblob/outblob usable by non-root apps

### DIFF
--- a/tsm-shim/README.md
+++ b/tsm-shim/README.md
@@ -59,3 +59,5 @@ phala cvms logs <app_id> -c app    # expect PASS and a ~5 KB quote
   dstack doesn't expose).
 - One request at a time, one shim per app — a shared `inblob`/`outblob` can't tell
   concurrent callers apart. An empty `outblob` read means the quote failed.
+- `inblob`/`outblob` are created mode `0666`, so a non-root app can use them. Set
+  `TSM_REPORT_MODE` (e.g. `0660`) on the `tsm-shim` service to restrict access.

--- a/tsm-shim/tsm_shim.py
+++ b/tsm-shim/tsm_shim.py
@@ -28,6 +28,10 @@ SOCKET = os.environ.get("DSTACK_SOCKET", "/var/run/dstack.sock")
 # How long to wait for the app to open outblob for reading before giving up, so a
 # caller that writes inblob then dies can't wedge the daemon.
 OUTBLOB_DEADLINE = float(os.environ.get("TSM_OUTBLOB_DEADLINE", "30"))
+# Mode for inblob/outblob. Default 0666 so a non-root app (any uid) in the same
+# container can read/write them -- the shared volume is the access boundary, not
+# the file bits. Set e.g. 0660 to restrict to the file's group.
+REPORT_MODE = int(os.environ.get("TSM_REPORT_MODE", "0666"), 8)
 
 
 def log(msg):
@@ -88,7 +92,8 @@ def open_write_deadline(path, deadline=30.0):
 def make_fifo(path):
     if os.path.lexists(path):
         os.remove(path)
-    os.mkfifo(path, 0o600)
+    os.mkfifo(path)
+    os.chmod(path, REPORT_MODE)  # chmod, not the mkfifo arg: the latter is cut by umask
 
 
 def main():


### PR DESCRIPTION
The shim created `inblob`/`outblob` as 0600 (root only), so a non-root app (e.g. uid 1000, no sudo) couldn't open them and quote generation failed. Now `chmod`ed to 0666 after creation (configurable via `TSM_REPORT_MODE`). Verified with an app running as uid 1000 (not in the root group).