### PR TITLE
fix(dstack-ingress): retry applying a renewed certificate until it sticks

### DIFF
--- a/custom-domain/dstack-ingress/scripts/dns01.sh
+++ b/custom-domain/dstack-ingress/scripts/dns01.sh
@@ -288,6 +288,10 @@ collect_evidence() {
     evidence_finalize
 }
 
+# Set when certificates have been renewed but not yet applied to haproxy.
+# Survives across passes, so a failed apply is retried on the next one.
+APPLY_PENDING=false
+
 # One pass over every domain: make the DNS records right, then issue or renew.
 # Idempotent, so the first pass and every later one are the same code.
 run_pass() {
@@ -306,9 +310,24 @@ run_pass() {
     done <<<"$(get-all-domains.sh)"
 
     if [ "$changed" -eq 1 ]; then
-        collect_evidence || echo "Evidence generation failed" >&2
-        build_combined_pems || echo "Combined PEM build failed" >&2
-        haproxy_reload || true
+        APPLY_PENDING=true
+    fi
+
+    # Applying is separate from renewing, and retried until it sticks. A
+    # renewal that reaches disk but not haproxy is invisible: the next pass
+    # sees a fresh certificate, reports "nothing to renew", and never reloads
+    # again -- so haproxy would serve the pre-renewal certificate until it
+    # expires, which is soon, because being near expiry is why it renewed.
+    if [ "$APPLY_PENDING" = true ]; then
+        local applied=true
+        collect_evidence || { echo "Evidence generation failed" >&2; applied=false; }
+        build_combined_pems || { echo "Combined PEM build failed" >&2; applied=false; }
+        haproxy_reload || applied=false
+        if [ "$applied" = true ]; then
+            APPLY_PENDING=false
+        else
+            echo "[$(date)] Certificate apply incomplete; retrying on the next pass" >&2
+        fi
     fi
     [ "$failed" -eq 0 ]
 }

--- a/custom-domain/dstack-ingress/scripts/tlsalpn.sh
+++ b/custom-domain/dstack-ingress/scripts/tlsalpn.sh
@@ -262,6 +262,10 @@ process_domain() {
     legoman.py auto --domain "$domain" ${ACME_EMAIL:+--email "$ACME_EMAIL"}
 }
 
+# Set when certificates have been renewed but not yet applied to haproxy.
+# Survives across passes, so a failed apply is retried on the next one.
+APPLY_PENDING=false
+
 # One pass over every domain: make sure the records exist, then issue or renew.
 # Idempotent, so the first pass and every later one are the same code. There is
 # deliberately only one of these -- an earlier split between a one-shot
@@ -285,9 +289,24 @@ run_pass() {
     done <<<"$(get-all-domains.sh)"
 
     if [ "$changed" -eq 1 ]; then
-        collect_evidence || echo "Evidence generation failed" >&2
-        build_combined_pems || echo "Combined PEM build failed" >&2
-        haproxy_reload || true
+        APPLY_PENDING=true
+    fi
+
+    # Applying is separate from renewing, and retried until it sticks. A
+    # renewal that reaches disk but not haproxy is invisible: the next pass
+    # sees a fresh certificate, reports "nothing to renew", and never reloads
+    # again -- so haproxy would serve the pre-renewal certificate until it
+    # expires, which is soon, because being near expiry is why it renewed.
+    if [ "$APPLY_PENDING" = true ]; then
+        local applied=true
+        collect_evidence || { echo "Evidence generation failed" >&2; applied=false; }
+        build_combined_pems || { echo "Combined PEM build failed" >&2; applied=false; }
+        haproxy_reload || applied=false
+        if [ "$applied" = true ]; then
+            APPLY_PENDING=false
+        else
+            echo "[$(date)] Certificate apply incomplete; retrying on the next pass" >&2
+        fi
     fi
     FIRST_PASS=false
     [ "$failed" -eq 0 ]


### PR DESCRIPTION
## Problem

Renewing a certificate and applying it were treated as one step:

```bash
if [ "$changed" -eq 1 ]; then
    collect_evidence     || echo "Evidence generation failed" >&2
    build_combined_pems  || echo "Combined PEM build failed" >&2
    haproxy_reload       || true
fi
```

Every failure there is swallowed, and none of them set `failed`, so the pass
still reports success. Twelve hours later the ACME client sees a fresh
certificate on disk, reports "nothing to renew", `changed` is 0, and the apply
is never attempted again.

HAProxy then goes on serving the *pre-renewal* certificate until it expires —
which is soon, because being close to expiry is why it renewed. The symptom
arrives weeks after the cause, as an expired certificate, with nothing in the
logs at that moment to connect the two.

## Fix

Separate renewing from applying. `APPLY_PENDING` is set when something renewed
and cleared only once evidence, PEMs and the reload have *all* succeeded, so a
failed apply is retried on the next pass instead of waiting for the next
renewal.

Quiet passes stay quiet: with nothing renewed and nothing pending, the block
does not run at all. This does not reintroduce the reload-on-every-check
behaviour that used to replace HAProxy's worker twice a day.

Kept in both mode scripts rather than lifted into a library — the apply steps
are mode-specific, since certbot and lego lay certificates out differently, so a
shared helper would have to call back into functions its callers define.

## Verification

The state machine, driven with stubbed apply steps:

| Pass | Input | Result |
|---|---|---|
| 1 | renewed, reload fails | `APPLY_PENDING` stays true |
| 2 | **nothing renewed** — where the old code gave up for good | retries, still fails |
| 3 | nothing renewed, reload recovers | applied, flag cleared |
| 4 | nothing renewed, nothing pending | completely silent |

Pass 2 is the bug. Pass 4 is the regression guard.

Container check: startup reaches placeholder → HAProxy → DNS wait as before, the
placeholder is served, and the container stays up (the startup pass runs bare
under `set -e`, so a stray non-zero there would kill it). Unit tests and the
sanitizer suite pass.

## Note

Rebased onto the current `main`, which no longer has `renew-certificate.sh` or
`renewal-daemon.sh` — #105 collapsed bootstrap and the renewal daemon into a
single owner per challenge type. Three of this PR's four original parts already
have equivalents there: the `exit 2` propagation, the `set -e` handling at the
call site, and reloading only when something actually renewed. What remains is
the part that had no equivalent, and it is simpler here — the original needed an
on-disk stamp to coordinate two processes, whereas one process now owns the
whole lifecycle, so an in-memory flag covers it. A container restart rebuilds
the PEMs from disk anyway.
