### PR TITLE
fix(prelaunch): v0.0.19 - correct SSH key count and log key fingerprints

### DIFF
--- a/phala-cloud-prelaunch-script/prelaunch.sh
+++ b/phala-cloud-prelaunch-script/prelaunch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 echo "----------------------------------------------"
-echo "Running Phala Cloud Pre-Launch Script v0.0.18"
+echo "Running Phala Cloud Pre-Launch Script v0.0.19"
 echo "----------------------------------------------"
 set -e
 
@@ -51,6 +51,40 @@ check_docker_login() {
     else
         return 1
     fi
+}
+
+# Function: print the SHA256 fingerprint of every authorized key
+#
+# Output matches `ssh-keygen -lf` and the fingerprints GitHub and Phala Cloud
+# display, so an operator can match the boot log against the account's key list.
+# The guest image ships neither ssh-keygen nor a base64 applet (BusyBox has
+# base32 only), so openssl does both the decode and the digest.
+print_authorized_key_fingerprints() {
+    local file="$1"
+    if ! command -v openssl >/dev/null 2>&1; then
+        echo "openssl not available; skipping SSH key fingerprints"
+        return 0
+    fi
+
+    local key_type blob comment decoded_bytes fingerprint
+    # `|| [[ -n "$key_type" ]]` keeps the final line when the file does not end
+    # with a newline; read returns non-zero there but still fills the variables.
+    while read -r key_type blob comment || [[ -n "$key_type" ]]; do
+        if [[ -z "$blob" ]]; then
+            continue
+        fi
+        # openssl exits 0 on undecodable input and emits nothing, which would
+        # otherwise print the SHA256 of the empty string as a real fingerprint.
+        decoded_bytes=$(printf '%s' "$blob" | openssl base64 -d -A 2>/dev/null | wc -c || true)
+        if [[ "$decoded_bytes" -eq 0 ]]; then
+            echo "  $key_type <unreadable key>"
+            continue
+        fi
+        fingerprint=$(
+            printf '%s' "$blob"                 | openssl base64 -d -A 2>/dev/null                 | openssl dgst -sha256 -binary 2>/dev/null                 | openssl base64 -A 2>/dev/null                 | tr -d '='                 || true
+        )
+        echo "  $key_type SHA256:$fingerprint"
+    done < "$file"
 }
 
 # Main logic starts here
@@ -309,13 +343,16 @@ if mkdir -p /home/root/.ssh 2>/dev/null; then
 
     if [[ -f /dstack/user_config ]] && jq empty /dstack/user_config 2>/dev/null; then
         if [[ $(jq 'has("ssh_authorized_keys")' /dstack/user_config 2>/dev/null) == "true" ]]; then
-            jq -j '.ssh_authorized_keys' /dstack/user_config >> /home/root/.ssh/authorized_keys
-            # Remove duplicates if there are multiple keys
-            if [[ $(cat /home/root/.ssh/authorized_keys | wc -l) -gt 1 ]]; then
-                sort -u /home/root/.ssh/authorized_keys > /home/root/.ssh/authorized_keys.tmp
-                mv /home/root/.ssh/authorized_keys.tmp /home/root/.ssh/authorized_keys
-            fi
-            echo "Set root authorized_keys from user preferences, total" $(cat /home/root/.ssh/authorized_keys | wc -l) "keys"
+            # jq -r terminates the value with a newline; jq -j does not, which
+            # both concatenated the next appended key onto the same line and
+            # made line-based counting report one key fewer than the file holds.
+            jq -r '.ssh_authorized_keys' /dstack/user_config >> /home/root/.ssh/authorized_keys
+            # Drop duplicates and the blank line an empty key list produces.
+            sort -u /home/root/.ssh/authorized_keys > /home/root/.ssh/authorized_keys.tmp
+            mv /home/root/.ssh/authorized_keys.tmp /home/root/.ssh/authorized_keys
+            KEY_COUNT=$(grep -c '^[^[:space:]]' /home/root/.ssh/authorized_keys || true)
+            echo "Set root authorized_keys from user preferences, total $KEY_COUNT keys"
+            print_authorized_key_fingerprints /home/root/.ssh/authorized_keys
         fi
     fi
 else


### PR DESCRIPTION
## Why

A CVM booting with one injected key logged:

```
Set root authorized_keys from user preferences, total 0 keys
```

The key was written and SSH worked — the count was wrong. It came from `wc -l`, which counts newlines, while `jq -j` writes the value with no trailing newline, so a one-key file counted as zero.

The same missing newline carried two more consequences: a later append concatenates onto the previous line and silently corrupts `authorized_keys`, and the `wc -l` > 1 guard kept the dedup pass from running for a two-key file.

## What changed in v0.0.19

- `jq -r` instead of `jq -j`, so the value is newline-terminated.
- Dedup runs unconditionally, which also drops the blank line an empty key list leaves behind.
- Counting uses a pattern that does not depend on the final newline.
- Every authorized key's SHA256 fingerprint is logged, in the format `ssh-keygen -lf` and GitHub use, so a boot log can be matched against the account's key list without shelling into the CVM.

```
Set root authorized_keys from user preferences, total 2 keys
  ssh-ed25519 SHA256:6OKoIHh0+L2URA+iptwZ1EF3NlwXZ6o0BW9/bnoR7ds
  ssh-rsa SHA256:LxIr2ZUyQLBZtTcELwmpjnhrYTYL/4ZUhXb2ngIo0RU
```

Both values are byte-identical to `ssh-keygen -lf` on the same keys.

## Guest image constraints

The guest image has neither `ssh-keygen` nor a `base64` applet — every dstack 0.5.x image builds BusyBox 1.36.1 from the same pinned kirkstone defconfig, which ships `base32` only. So `openssl` performs both the decode and the digest, guarded by a `command -v` check. `openssl` is present in every 0.5.x image via ca-certificates, the same dependency v0.0.18 already relies on for `openssl passwd -6`.

`openssl base64 -d` exits 0 on undecodable input and emits nothing, which would print the SHA256 of the empty string as a real fingerprint. The decoded byte count is checked first, and such a line prints `<unreadable key>` instead.

Reading the file uses `while read ... || [[ -n "$key_type" ]]` so a file with no final newline does not lose its last line — the same trailing-newline trap this release fixes.

## Verification

Exercised locally against the committed file with real keys, covering repeat execution (idempotent — no duplicate or concatenated lines on a second boot), an empty key list, a file with no final newline, and an undecodable blob. `bash -n` clean.