### PR TITLE
fix(ingress): normalize requirements file mode

### DIFF
--- a/custom-domain/dstack-ingress/Dockerfile
+++ b/custom-domain/dstack-ingress/Dockerfile
@@ -62,7 +62,8 @@ RUN mkdir -p \
 # installation from PyPI would leave certbot (which handles TLS private keys)
 # outside the measured image.  Keep versions explicit; update this list only
 # together with a new image build and digest.
-COPY requirements.txt /tmp/requirements.txt
+# Normalize the mode so the image digest does not depend on the checkout umask.
+COPY --chmod=644 requirements.txt /tmp/requirements.txt
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONHASHSEED=0 \
     SOURCE_DATE_EPOCH=0


### PR DESCRIPTION
## Summary

- normalize `requirements.txt` to mode `0644` when copying it into the image
- prevent the published image digest from depending on the checkout umask

## Verification

Built from a worktree where `requirements.txt` had mode `0664`:

```text
sha256:cd54c56c943d6a9b96e9ffd7683e742fbc551124a4a1960553d0d022a9f632ce
```

This exactly matches the published `dstacktee/dstack-ingress:2.4` digest.
