### PR TITLE
fix(ingress): retain classical TLS group fallbacks

### DIFF
--- a/custom-domain/dstack-ingress/scripts/haproxy-lib.sh
+++ b/custom-domain/dstack-ingress/scripts/haproxy-lib.sh
@@ -31,7 +31,7 @@ global
     ssl-default-bind-ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305
     ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
     ssl-default-bind-options ssl-min-ver TLSv1.2 no-tls-tickets
-    ssl-default-bind-curves X25519MLKEM768:secp384r1
+    ssl-default-bind-curves X25519MLKEM768:X25519:secp256r1:secp384r1
 
 defaults
     log     global

--- a/custom-domain/dstack-ingress/scripts/tests/test_x25519mlkem768.sh
+++ b/custom-domain/dstack-ingress/scripts/tests/test_x25519mlkem768.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Verify that the ingress image can terminate TLS 1.3 with the
-# X25519MLKEM768 hybrid key-exchange group.
+# Verify that the ingress image can terminate TLS 1.3 with the configured
+# post-quantum hybrid group and classical fallback groups.
 #
 # Usage: ./scripts/tests/test_x25519mlkem768.sh <image>
 
@@ -42,17 +42,25 @@ EOF
     exec haproxy -W -db -f /etc/haproxy/haproxy.cfg
 ' >/dev/null
 
-for _ in {1..20}; do
-    handshake="$(docker exec "${CONTAINER}" bash -c \
-        'openssl s_client -connect 127.0.0.1:24443 -servername localhost -tls1_3 -groups X25519MLKEM768 </dev/null 2>&1' \
-        || true)"
-    if grep -Fq 'Negotiated TLS1.3 group: X25519MLKEM768' <<<"${handshake}"; then
-        grep -F 'Negotiated TLS1.3 group: X25519MLKEM768' <<<"${handshake}"
-        exit 0
-    fi
-    sleep 0.1
-done
+for group in X25519MLKEM768 X25519 secp256r1 secp384r1; do
+    handshake=""
+    for _ in {1..20}; do
+        handshake="$(docker exec "${CONTAINER}" bash -c \
+            "openssl s_client -connect 127.0.0.1:24443 -servername localhost -tls1_3 -groups ${group} </dev/null 2>&1" \
+            || true)"
+        # Each client offers exactly one group, so a successful TLS 1.3
+        # handshake proves HAProxy selected that configured group. OpenSSL
+        # only prints "Negotiated TLS1.3 group" for some group types.
+        if grep -Fq 'Protocol: TLSv1.3' <<<"${handshake}"; then
+            echo "TLS 1.3 handshake completed with ${group}"
+            break
+        fi
+        sleep 0.1
+    done
 
-printf '%s\n' "${handshake}" >&2
-echo 'X25519MLKEM768 TLS handshake did not complete' >&2
-exit 1
+    if ! grep -Fq 'Protocol: TLSv1.3' <<<"${handshake}"; then
+        printf '%s\n' "${handshake}" >&2
+        echo "${group} TLS handshake did not complete" >&2
+        exit 1
+    fi
+done


### PR DESCRIPTION
## Summary
- retain X25519, P-256, and P-384 fallback groups alongside X25519MLKEM768
- verify each configured group with a local TLS 1.3 handshake

## Verification
- `./build-image.sh`
- `bash scripts/tests/test_x25519mlkem768.sh dstack-ingress-fallback-test:local`
- `bash scripts/tests/test_sanitizers.sh`
- `python3 scripts/tests/test_certman.py`
- `python3 scripts/tests/test_dnsguide.py`
- `python3 scripts/tests/test_deterministic_key.py`